### PR TITLE
Remove unnecessary cd for run_as_module=True (fixes #69)

### DIFF
--- a/cluster_utils/job.py
+++ b/cluster_utils/job.py
@@ -147,10 +147,7 @@ class Job:
                 module_name = (
                     paths["script_to_run"].replace("/", ".").replace(".py", "")
                 )
-                exec_cmd = (
-                    f"cd {paths['main_path']}; {python_executor} -m"
-                    f" {module_name} {comm_info_string} {setting_string}"
-                )
+                exec_cmd = f"{python_executor} -m {module_name} {comm_info_string} {setting_string}"
             else:
                 base_exec_cmd = "{}".format(python_executor) + " {} {} {}"
                 exec_cmd = base_exec_cmd.format(


### PR DESCRIPTION
Changing the directory should not be necessary at that point because it is already done at an earlier point in the job launch script. Additionally, using `cd` this way is not compatible with singularity (see #69).