### PR TITLE
Fix: lint dependency not installed for dev group

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             "ruff==0.1.15",
         ],
         "dev": [
-            "cluster[lint]",
+            "cluster_utils[lint]",
             "absolufy-imports",
             "nox>=2022.8.7",
             "pre-commit",


### PR DESCRIPTION
The dependency "cluster[dev]" does not exist anymore, and so the lint group was not installed on installing the dev group.