### PR TITLE
chore: Disable test on Python 3.12

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For some reason running the tests with Python 3.12 takes very long. For now, simply disable testing with 3.12.