### PR TITLE
Slurm: Add new option to send USR1 signal before timeout

### DIFF
--- a/cluster_utils/job.py
+++ b/cluster_utils/job.py
@@ -84,7 +84,19 @@ class Job:
         current_setting["id"] = self.id
         return current_setting
 
-    def generate_execution_cmd(self, paths):
+    def generate_execution_cmd(self, paths, cmd_prefix: Optional[str] = None):
+        """Generate the commands to execute the job.
+
+        Args:
+            paths: Dictionary containing relevant paths.
+            cmd_prefix: String that is prepended to the command that runs the user
+                script.  Can be used to wrap in in some cluster-system-specific command
+                (e.g. to use `srun` on Slurm).
+
+        Returns:
+            Shell script running the job (includes cd-ing to the source directory,
+            activating virtual environments, etc.).
+        """
         logger = logging.getLogger("cluster_utils")
         current_setting = self.generate_final_setting(paths)
 
@@ -170,6 +182,9 @@ class Job:
                 paths["main_path"],
                 current_setting["working_dir"],
             )
+
+        if cmd_prefix:
+            exec_cmd = f"{cmd_prefix} {exec_cmd}"
 
         res = "\n".join(
             [

--- a/cluster_utils/job.py
+++ b/cluster_utils/job.py
@@ -90,7 +90,7 @@ class Job:
         Args:
             paths: Dictionary containing relevant paths.
             cmd_prefix: String that is prepended to the command that runs the user
-                script.  Can be used to wrap in in some cluster-system-specific command
+                script.  Can be used to wrap in some cluster-system-specific command
                 (e.g. to use `srun` on Slurm).
 
         Returns:

--- a/cluster_utils/slurm_cluster_system.py
+++ b/cluster_utils/slurm_cluster_system.py
@@ -24,7 +24,7 @@ echo "==== Start execution. ===="
 echo "Job id: {id}, cluster id: ${{SLURM_JOB_ID}}, hostname: $(hostname), time: $(date)"
 echo
 
-{cmd}
+srun {cmd}
 rc=$?
 if [[ $rc == %(RETURN_CODE_FOR_RESUME)d ]]; then
     echo "exit with code %(RETURN_CODE_FOR_RESUME)d for resume"

--- a/cluster_utils/slurm_cluster_system.py
+++ b/cluster_utils/slurm_cluster_system.py
@@ -70,7 +70,7 @@ class SlurmJobRequirements(NamedTuple):
         req = dict(requirements)
 
         try:
-            signal_time = req.pop("timeout_signal_time", None)
+            signal_time = req.pop("signal_seconds_to_timeout", None)
             if signal_time:
                 signal = f"USR1@{signal_time:d}"
             else:

--- a/cluster_utils/slurm_cluster_system.py
+++ b/cluster_utils/slurm_cluster_system.py
@@ -24,7 +24,7 @@ echo "==== Start execution. ===="
 echo "Job id: {id}, cluster id: ${{SLURM_JOB_ID}}, hostname: $(hostname), time: $(date)"
 echo
 
-srun {cmd}
+{cmd}
 rc=$?
 if [[ $rc == %(RETURN_CODE_FOR_RESUME)d ]]; then
     echo "exit with code %(RETURN_CODE_FOR_RESUME)d for resume"
@@ -231,7 +231,8 @@ class SlurmClusterSubmission(ClusterSubmission):
         runs_script_name = "job_{}_{}.sh".format(job.iteration, job.id)
         submission_dir = pathlib.Path(self.submission_dir)
         run_script_file_path = submission_dir / runs_script_name
-        cmd = job.generate_execution_cmd(self.paths)
+        # need to prefix the actual job command with `srun` so that --signal works.
+        cmd = job.generate_execution_cmd(self.paths, cmd_prefix="srun")
 
         stdout_file = run_script_file_path.with_suffix(".out")
         stderr_file = run_script_file_path.with_suffix(".err")

--- a/cluster_utils/slurm_cluster_system.py
+++ b/cluster_utils/slurm_cluster_system.py
@@ -7,7 +7,7 @@ import pathlib
 import subprocess
 import time
 from subprocess import PIPE, run
-from typing import Any, NamedTuple, Sequence
+from typing import Any, NamedTuple, Optional, Sequence
 
 from . import settings
 from .cluster_system import ClusterJobId, ClusterSubmission, SubmissionError
@@ -52,6 +52,8 @@ class SlurmJobRequirements(NamedTuple):
     # exclude specific list of hosts
     exclude: list[str]
 
+    signal: Optional[str]
+
     # list of arbitrary sbatch options for things that are not covered by the settings
     # above (e.g. something like "--gpu-freq=high")
     extra_submission_options: list[str]
@@ -68,6 +70,12 @@ class SlurmJobRequirements(NamedTuple):
         req = dict(requirements)
 
         try:
+            signal_time = req.pop("timeout_signal_time", None)
+            if signal_time:
+                signal = f"USR1@{signal_time:d}"
+            else:
+                signal = None
+
             obj = cls(
                 partition=req.pop("partition"),
                 cpus_per_task=req.pop("request_cpus"),
@@ -75,6 +83,7 @@ class SlurmJobRequirements(NamedTuple):
                 mem="{}M".format(req.pop("memory_in_mb")),
                 time=req.pop("request_time"),
                 exclude=req.pop("forbidden_hostnames", []),
+                signal=signal,
                 extra_submission_options=req.pop("extra_submission_options", []),
             )
         except KeyError as e:
@@ -241,6 +250,9 @@ class SlurmClusterSubmission(ClusterSubmission):
 
         if self.requirements.exclude:
             args.add("exclude", ",".join(self.requirements.exclude))
+
+        if self.requirements.signal:
+            args.add("signal", self.requirements.signal)
 
         args.extend_raw(self.requirements.extra_submission_options)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -240,6 +240,11 @@ Slurm-specific Options
         "days-hours:minutes:seconds".
 
     So for example to request 1 hour per job use ``request_time = "1:00:00"``.
+- ``timeout_signal_time`` --- *int*
+    Time in seconds before timeout at which Slurm sends a USR1 signal to the job (see
+    ``--signal`` of ``sbatch``).  If not set, no signal is sent.
+
+    See example :doc:`examples/slurm_timeout_signal`.
 - ``extra_submission_options`` --- *list[str]*
     List of additional options for ``sbatch``.  Can be used if a specific
     setting is needed which is not already covered by the options above.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -240,7 +240,7 @@ Slurm-specific Options
         "days-hours:minutes:seconds".
 
     So for example to request 1 hour per job use ``request_time = "1:00:00"``.
-- ``timeout_signal_time`` --- *int*
+- ``signal_seconds_to_timeout`` --- *int*
     Time in seconds before timeout at which Slurm sends a USR1 signal to the job (see
     ``--signal`` of ``sbatch``).  If not set, no signal is sent.
 

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,0 +1,8 @@
+********
+Examples
+********
+
+.. toctree::
+   :maxdepth: 1
+
+   slurm_timeout_signal.rst

--- a/docs/examples/slurm_timeout_signal.rst
+++ b/docs/examples/slurm_timeout_signal.rst
@@ -44,3 +44,11 @@ checkpoint will be saved and the script terminates with ``exit_for_resume``.
 
    This example is included in ``cluster_utils/examples/slurm_timeout_signal``
    and can be directly run from there.
+
+.. warning::
+
+   In case you are using a wrapper script around your main.py (can for example be needed
+   for some environment setup inside containers), the signal will only be sent to the
+   wrapper script and not automatically be forwarded to the main.py process.
+   So in this case, you need to catch the signal in the wrapper script as well and sent
+   it to the child process from there.

--- a/docs/examples/slurm_timeout_signal.rst
+++ b/docs/examples/slurm_timeout_signal.rst
@@ -22,7 +22,7 @@ can be done is shown below as well.
 
 .. literalinclude:: ../../examples/slurm_timeout_signal/grid_search.toml
 
-The relevant part here is the definition of ``timeout_signal_time`` in the
+The relevant part here is the definition of ``signal_seconds_to_timeout`` in the
 ``[cluster_requirements]`` section.  When defining it, Slurm will be configured to send a ``USR1`` signal to warn about the approaching timeout.  The value is the approximate time in seconds before the TIMEOUT at which the signal will be sent.  Make sure to choose a value large enough to allow your job to actually save the intermediate data before the timeout is reached.
 
 The main script of the job can then look something like this:

--- a/docs/examples/slurm_timeout_signal.rst
+++ b/docs/examples/slurm_timeout_signal.rst
@@ -1,0 +1,46 @@
+**********************************
+Get Signal Before Timeout on Slurm
+**********************************
+
+Slurm requires jobs to specify a maximum run duration.  Jobs that exceed this
+duration will get killed.  This can be a problem in cases where you do not know
+the exact run duration of your jobs in advance.  Fortunately, Slurm can be
+configured to send a signal to the job a bit before the timeout.  This allows
+the job to save a checkpoint with the current results and use cluster_utils'
+``exit_for_resume`` to terminate.  cluster_utils will then automatically restart
+the job, allowing it to load the previously saved checkpoint and resume the
+computations.
+
+
+Below is a small example on how to configure cluster_utils such that
+timeout-warning signals are send.  Please note that it is still up to you to
+catch that signal in your code and react accordingly.  An example on how this
+can be done is shown below as well.
+
+
+**grid_search.toml:**
+
+.. literalinclude:: ../../examples/slurm_timeout_signal/grid_search.toml
+
+The relevant part here is the definition of ``timeout_signal_time`` in the
+``[cluster_requirements]`` section.  When defining it, Slurm will be configured to send a ``USR1`` signal to warn about the approaching timeout.  The value is the approximate time in seconds before the TIMEOUT at which the signal will be sent.  Make sure to choose a value large enough to allow your job to actually save the intermediate data before the timeout is reached.
+
+The main script of the job can then look something like this:
+
+**main.py:**
+
+.. literalinclude:: ../../examples/slurm_timeout_signal/main.py
+
+
+A signal handler is registered with ``signal.signal(signal.SIGUSR1,
+timeout_signal_handler)``.  This means the given function will be called when
+the process receives a ``USR1`` signal.  What this function does will then
+depend on the actual application.  In the example, it simply sets a flag which
+will be checked in each iteration of the dummy training loop.  If set True, a
+checkpoint will be saved and the script terminates with ``exit_for_resume``.
+
+
+.. note::
+
+   This example is included in ``cluster_utils/examples/slurm_timeout_signal``
+   and can be directly run from there.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ Documentation Content
    report
    troubleshooting
    setup_devel_env
+   examples/index.rst
 
 
 .. toctree::

--- a/examples/slurm_timeout_signal/grid_search.toml
+++ b/examples/slurm_timeout_signal/grid_search.toml
@@ -1,0 +1,28 @@
+optimization_procedure_name = "timeout_signal_test"
+results_dir = "/tmp/slurm_timeout_signal_example"
+generate_report = "when_finished"
+script_relative_path = "examples/slurm_timeout_signal/main.py"
+remove_jobs_dir = false
+restarts = 1
+
+[git_params]
+branch = "master"
+
+[environment_setup]
+
+[cluster_requirements]
+partition = "cpu-galvani"
+request_cpus = 1
+memory_in_mb = 1000
+request_time = "00:04:00"  # jobs get killed after 4 minutes
+timeout_signal_time = 30  # sent signal at least 30 seconds before timeout
+
+[fixed_params]
+
+[[hyperparam_list]]
+param = "x"
+values = [0, 1]
+
+[[hyperparam_list]]
+param = "y"
+values = [0, 1]

--- a/examples/slurm_timeout_signal/grid_search.toml
+++ b/examples/slurm_timeout_signal/grid_search.toml
@@ -15,7 +15,7 @@ partition = "cpu-galvani"
 request_cpus = 1
 memory_in_mb = 1000
 request_time = "00:04:00"  # jobs get killed after 4 minutes
-timeout_signal_time = 30  # sent signal at least 30 seconds before timeout
+signal_seconds_to_timeout = 30  # sent signal at least 30 seconds before timeout
 
 [fixed_params]
 

--- a/examples/slurm_timeout_signal/main.py
+++ b/examples/slurm_timeout_signal/main.py
@@ -1,0 +1,62 @@
+"""Minimal example on how to use the timeout signal sent by Slurm."""
+
+import json
+import pathlib
+import signal
+import sys
+import time
+
+import cluster_utils
+
+received_timeout_signal = False
+
+
+def timeout_signal_handler(sig, frame):
+    global received_timeout_signal
+
+    print("Received timeout signal")
+    # simply set a flag here, which is checked in the training loop
+    received_timeout_signal = True
+
+
+def main() -> int:
+    """Main function."""
+    params = cluster_utils.read_params_from_cmdline()
+
+    n_training_iterations = 60
+    start_iteration = 0
+
+    # register signal handler for the USR1 signal
+    signal.signal(signal.SIGUSR1, timeout_signal_handler)
+
+    checkpoint_file = pathlib.Path(params.working_dir) / "checkpoint.json"
+
+    # load existing checkpoint
+    if checkpoint_file.exists():
+        print("Load checkpoint")
+        with open(checkpoint_file) as f:
+            chkpnt = json.load(f)
+            start_iteration = chkpnt["iteration"]
+
+    for i in range(start_iteration, n_training_iterations):
+        print(f"Training iteration {i} with x = {params.x}, y = {params.y}")
+        time.sleep(10)  # dummy sleep instead of an actual training
+
+        if received_timeout_signal:
+            print("Save checkpoint and exit for resume.")
+            # save checkpoint
+            with open(checkpoint_file, "w") as f:
+                json.dump({"iteration": i + 1}, f)
+
+            # exit and ask cluster_utils to restart this job
+            cluster_utils.exit_for_resume()
+
+    # just return some dummy metric value here
+    metrics = {"result": params.x + params.y, "n_iterations": i}
+    cluster_utils.save_metrics_params(metrics, params)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_slurm_cluster_system.py
+++ b/tests/test_slurm_cluster_system.py
@@ -76,7 +76,7 @@ def test_generate_run_script(job_data):
 
     assert job_data.job.run_script_path == str(expected_path)
 
-    job_cmd = job_data.job.generate_execution_cmd(job_data.paths)
+    job_cmd = job_data.job.generate_execution_cmd(job_data.paths, cmd_prefix="srun")
     run_script = run_script_path.read_text()
     assert (
         run_script


### PR DESCRIPTION
# TL;DR
Add option to send signal to jobs before they are killed by timeout.

# Long Version
Add a new option `timeout_signal_time` in the cluster_requirements section.  If set, it adds `--signal=USR1@<time>` to the `sbatch` call, resulting in Slurm to send a USR1 signal at the specified time (in seconds) before it would kill the job due to timeout.

For the signal to actually be sent to the process running the main script, this needs to be executed with `srun`, so some change in the job command creation is needed to inject that for Slurm jobs.

Also add an example and embed it in the documentation.

Resolves #64.

# How I Tested
By running the example.