### PR TITLE
Remove language version from black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     rev: 24.3.0
     hooks:
     -   id: black
-        language_version: python3.8
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.15
     hooks:


### PR DESCRIPTION
This config setting made the pre-commit environment dependent on having that Python version installed, rendering pre-commit unusable for other Python versions.