### PR TITLE
doc: Add basic how-to page for exit_for_resume()

### DIFF
--- a/cluster_utils/settings.py
+++ b/cluster_utils/settings.py
@@ -192,6 +192,11 @@ def announce_early_results(metrics):
 
 
 def exit_for_resume():
+    """Send a "resume"-request to the cluster_utils server and exit with returncode 3.
+
+    Use this to split a single long-running job into multiple shorter jobs by frequently
+    saving intermediate results and restarting by calling this function.
+    """
     if not submission_state.connection_active:
         # TODO: shouldn't it at least sys.exit() in any case?
         return

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ import typing
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx.ext.autodoc",
     "sphinx.ext.todo",
     "myst_parser",
     "sphinx_immaterial",

--- a/docs/examples/checkpointing.rst
+++ b/docs/examples/checkpointing.rst
@@ -1,0 +1,26 @@
+.. _example_checkpointing:
+
+********************************************
+Use checkpointing with ``exit_for_resume()``
+********************************************
+
+
+This is an example how to use checkpointing and restarting jobs using
+:func:`~cluster_utils.exit_for_resume()` when training a neural network with PyTorch.
+
+For more information on :func:`~cluster_utils.exit_for_resume()` see
+:ref:`exit_for_resume`.
+
+
+.. literalinclude:: ../../examples/checkpointing/checkpoint_example.py
+
+
+The corresponding cluster_utils config file:
+
+.. literalinclude:: ../../examples/checkpointing/grid_search_checkpointing.json
+
+
+.. note::
+
+   This example is included in ``cluster_utils/examples/checkpointing`` and can be
+   directly run from there.

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -6,3 +6,4 @@ Examples
    :maxdepth: 1
 
    slurm_timeout_signal.rst
+   checkpointing.rst

--- a/docs/examples/slurm_timeout_signal.rst
+++ b/docs/examples/slurm_timeout_signal.rst
@@ -1,3 +1,5 @@
+.. _example_slurm_timeout_signal:
+
 **********************************
 Get Signal Before Timeout on Slurm
 **********************************
@@ -7,9 +9,9 @@ duration will get killed.  This can be a problem in cases where you do not know
 the exact run duration of your jobs in advance.  Fortunately, Slurm can be
 configured to send a signal to the job a bit before the timeout.  This allows
 the job to save a checkpoint with the current results and use cluster_utils'
-``exit_for_resume`` to terminate.  cluster_utils will then automatically restart
-the job, allowing it to load the previously saved checkpoint and resume the
-computations.
+:func:`~cluster_utils.exit_for_resume` to terminate.  cluster_utils will then
+automatically restart the job, allowing it to load the previously saved checkpoint and
+resume the computations.
 
 
 Below is a small example on how to configure cluster_utils such that
@@ -37,7 +39,8 @@ timeout_signal_handler)``.  This means the given function will be called when
 the process receives a ``USR1`` signal.  What this function does will then
 depend on the actual application.  In the example, it simply sets a flag which
 will be checked in each iteration of the dummy training loop.  If set True, a
-checkpoint will be saved and the script terminates with ``exit_for_resume``.
+checkpoint will be saved and the script terminates with
+:func:`~cluster_utils.exit_for_resume`.
 
 
 .. note::

--- a/docs/exit_for_resume.rst
+++ b/docs/exit_for_resume.rst
@@ -1,0 +1,42 @@
+****************************************
+Restart jobs using ``exit_for_resume()``
+****************************************
+
+When using cluster systems, it can often be beneficial to split long-running jobs into
+multiple shorter jobs.  Reasons for this are:
+
+- Jobs with lower time requirements can potentially be scheduled sooner (e.g. on Slurm).
+- On some systems the cost for running jobs increases non-linearly over time, so
+  multiple short jobs are cheaper than one long one.
+- On systems where one needs to specify time limits (e.g. Slurm), restarting can be used
+  to avoid timeouts if the duration needed for the job is not known in advance.
+- Stopping from time to time gives other users a chance to start their jobs in between,
+  so it's more friendly to your colleagues.
+
+
+cluster_utils supports this via the function :func:`~cluster_utils.exit_for_resume`.
+Calling it will send a resume-request to the cluster_utils main process and then
+terminate the job.  The main process will then re-submit the job with the same settings
+and same output directory.  This allows the job to load previously saved intermediate
+results and proceed working on them.
+
+
+So the high level structure of a job script using
+:func:`~cluster_utils.exit_for_resume` looks like this:
+
+1. In the beginning of your script check if there are intermediate results saved in the
+   output directory by a previous job.  If yes, load them.
+2. Start/proceed your computations.
+3. Based on some criterion (e.g. after a certain number of iterations or when receiving
+   a timeout-signal by Slurm) save current results to the output directory and terminate
+   the job by calling :func:`~cluster_utils.exit_for_resume`.
+
+
+A concrete, runnable example using this in combination with Slurm's timeout signal can
+be found in :ref:`example_slurm_timeout_signal`.
+
+
+API
+===
+
+.. autofunction:: cluster_utils.exit_for_resume

--- a/docs/exit_for_resume.rst
+++ b/docs/exit_for_resume.rst
@@ -1,3 +1,5 @@
+.. _exit_for_resume:
+
 ****************************************
 Restart jobs using ``exit_for_resume()``
 ****************************************
@@ -32,8 +34,11 @@ So the high level structure of a job script using
    the job by calling :func:`~cluster_utils.exit_for_resume`.
 
 
-A concrete, runnable example using this in combination with Slurm's timeout signal can
-be found in :ref:`example_slurm_timeout_signal`.
+Usage Examples
+==============
+
+- :ref:`example_checkpointing`
+- :ref:`example_slurm_timeout_signal` (combines restarting with Slurm's timeout signal)
 
 
 API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ Documentation Content
    report
    troubleshooting
    setup_devel_env
+   exit_for_resume.rst
    examples/index.rst
 
 

--- a/examples/checkpointing/checkpoint_example.py
+++ b/examples/checkpointing/checkpoint_example.py
@@ -5,8 +5,8 @@ import torch
 
 from cluster_utils import (
     exit_for_resume,
+    read_params_from_cmdline,
     save_metrics_params,
-    update_params_from_cmdline,
 )
 
 
@@ -41,10 +41,10 @@ def load_checkpoint(load_path, model, optim):
 
 if __name__ == "__main__":
     # parameters are loaded from json file
-    params = update_params_from_cmdline()
+    params = read_params_from_cmdline()
     # a folder for each run is created
-    os.makedirs(params.model_dir, exist_ok=True)
-    checkpoint_path = os.path.join(params.model_dir, "checkpoint.pt")
+    os.makedirs(params.working_dir, exist_ok=True)
+    checkpoint_path = os.path.join(params.working_dir, "checkpoint.pt")
     # these are taken from json file for illustration
     total_iterations = params.total_iterations
 
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     iteration = load_checkpoint(checkpoint_path, model, optim)
     # redirect output to log file for easier understanding what happens
     # the log file is written after the program ends.
-    sys.stdout = open(f"{params.model_dir}/log_{iteration}.txt", "w")  # noqa: SIM115
+    sys.stdout = open(f"{params.working_dir}/log_{iteration}.txt", "w")  # noqa: SIM115
 
     while True:
         # do some training
@@ -77,7 +77,7 @@ if __name__ == "__main__":
             # we first save the necessary data to restart our job
             save_checkpoint(checkpoint_path, model, optim, iteration)
             # then we exit the job by calling a special function
-            # htcondor internally restarts the job in the same cluster_utils model_dir
+            # htcondor internally restarts the job in the same cluster_utils working_dir
             # you will not see this in the utils progress bar, check
             # /working_directories/0/log.txt after the job
             print(f"Exit job at iteration {iteration}")


### PR DESCRIPTION
This is a rather important feature of cluster_utils but it seems it wasn't explained anywhere so far.

The screenshot below shows how the rendered page looks.
![2024-04-29 12 23 48  30b20e5f8da6](https://github.com/martius-lab/cluster_utils/assets/9333121/2e02c685-1eb0-436f-b792-4fd532d0e690)
