### PR TITLE
Consider non-zero return codes as failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still work for now (see Deprecated section) but in commands for running
   hp_optimization/grid_search need to be changed accordingly (e.g. `python3 -m
   cluster_utils.grid_search ...`)
+- **Breaking:** All exit codes other than 0 or 3 (the magic "restart for resume" code)
+  are now considered as failures.  Previously only 1 was considered as failure.
 - The raw data of `grid_search` is saved to a file "all_data.csv" instead of
   "results_raw.csv" to be consistent with `hp_optimization` (the format of the file
   didn't change, only the name).

--- a/cluster_utils/condor_cluster_system.py
+++ b/cluster_utils/condor_cluster_system.py
@@ -28,8 +28,8 @@ if [[ $rc == 0 ]]; then
 elif [[ $rc == {RETURN_CODE_FOR_RESUME} ]]; then
     echo "exit with code {RETURN_CODE_FOR_RESUME} for resume"
     exit {RETURN_CODE_FOR_RESUME}
-elif [[ $rc == 1 ]]; then
-    exit 1
+elif [[ $rc != 0 ]]; then
+    exit $rc
 fi
 """
 # TODO: the MPI_CLUSTER_RUN_SCRIPT above does not forward errorcodes other than 1 and 3.

--- a/cluster_utils/condor_cluster_system.py
+++ b/cluster_utils/condor_cluster_system.py
@@ -29,6 +29,9 @@ elif [[ $rc == {RETURN_CODE_FOR_RESUME} ]]; then
     echo "exit with code {RETURN_CODE_FOR_RESUME} for resume"
     exit {RETURN_CODE_FOR_RESUME}
 elif [[ $rc != 0 ]]; then
+    echo "Failed with exit code $rc"
+    # add an indicator file to more easily identify failed jobs
+    echo "$rc" > "%(run_script_file_path)s.FAILED"
     exit $rc
 fi
 """

--- a/cluster_utils/dummy_cluster_system.py
+++ b/cluster_utils/dummy_cluster_system.py
@@ -29,7 +29,15 @@ exec 1>>"$output"
 exec 2>>"$error"
 
 %(cmd)s
-exit $?
+rc=$?
+
+if [[ $rc != 0 ]]; then
+    echo "Failed with exit code $rc"
+    # add an indicator file to more easily identify failed jobs
+    echo "$rc" > "%(run_script_file_path)s.FAILED"
+fi
+
+exit $rc
 """
 
 

--- a/cluster_utils/slurm_cluster_system.py
+++ b/cluster_utils/slurm_cluster_system.py
@@ -36,7 +36,7 @@ if [[ $rc == %(RETURN_CODE_FOR_RESUME)d ]]; then
 elif [[ $rc != 0 ]]; then
     echo "Failed with exit code $rc"
     # add an indicator file to more easily identify failed jobs
-    touch "{run_script_file_path}.FAILED"
+    echo "$rc" > "{run_script_file_path}.FAILED"
     exit $rc
 fi
 """ % {

--- a/cluster_utils/slurm_cluster_system.py
+++ b/cluster_utils/slurm_cluster_system.py
@@ -27,14 +27,17 @@ echo
 
 {cmd}
 rc=$?
+
+echo "==== Finished execution. ===="
 if [[ $rc == %(RETURN_CODE_FOR_RESUME)d ]]; then
-    echo "exit with code %(RETURN_CODE_FOR_RESUME)d for resume"
+    echo "Exit with code %(RETURN_CODE_FOR_RESUME)d for resume"
     # do not forward the exit code, as otherwise Slurm will think there was an error
     exit 0
-elif [[ $rc == 1 ]]; then
+elif [[ $rc != 0 ]]; then
+    echo "Failed with exit code $rc"
     # add an indicator file to more easily identify failed jobs
     touch "{run_script_file_path}.FAILED"
-    exit 1
+    exit $rc
 fi
 """ % {
     "RETURN_CODE_FOR_RESUME": RETURN_CODE_FOR_RESUME

--- a/tests/test_slurm_cluster_system.py
+++ b/tests/test_slurm_cluster_system.py
@@ -111,7 +111,7 @@ if [[ $rc == 3 ]]; then
 elif [[ $rc != 0 ]]; then
     echo "Failed with exit code $rc"
     # add an indicator file to more easily identify failed jobs
-    touch "{job_data.jobs_dir}/job_2_13.sh.FAILED"
+    echo "$rc" > "{job_data.jobs_dir}/job_2_13.sh.FAILED"
     exit $rc
 fi
 """

--- a/tests/test_slurm_cluster_system.py
+++ b/tests/test_slurm_cluster_system.py
@@ -102,14 +102,17 @@ echo
 
 {job_cmd}
 rc=$?
+
+echo "==== Finished execution. ===="
 if [[ $rc == 3 ]]; then
-    echo "exit with code 3 for resume"
+    echo "Exit with code 3 for resume"
     # do not forward the exit code, as otherwise Slurm will think there was an error
     exit 0
-elif [[ $rc == 1 ]]; then
+elif [[ $rc != 0 ]]; then
+    echo "Failed with exit code $rc"
     # add an indicator file to more easily identify failed jobs
     touch "{job_data.jobs_dir}/job_2_13.sh.FAILED"
-    exit 1
+    exit $rc
 fi
 """
     )


### PR DESCRIPTION
Instead of just checking `$rc == 1` consider all non-zero return codes (except the magic `RETURN_CODE_FOR_RESUME` code) as failure.

This fixes #87 and #42.

# Do not merge before
- #98

# How I Tested
By running examples on Slurm, Condor and locally