### PR TITLE
docs: Add API Reference page

### DIFF
--- a/cluster_utils/constants.py
+++ b/cluster_utils/constants.py
@@ -1,5 +1,8 @@
+#: Name of the CSV file to which used parameters of a job are saved.
 CLUSTER_PARAM_FILE = "param_choice.csv"
+#: Name of the CSV file to which resulting metrics of a job are saved.
 CLUSTER_METRIC_FILE = "metrics.csv"
+#: Name of the JSON file to which used parameters of a job are saved.
 JSON_SETTINGS_FILE = "settings.json"
 
 METADATA_FILE = "metadata.json"

--- a/cluster_utils/settings.py
+++ b/cluster_utils/settings.py
@@ -13,7 +13,7 @@ import socket
 import sys
 import time
 import traceback
-from typing import Any, NamedTuple, Optional
+from typing import Any, MutableMapping, NamedTuple, Optional, cast
 
 import pyuv
 import smart_settings
@@ -251,7 +251,7 @@ def sanitize_numpy_torch(possibly_np_or_tensor):
     return possibly_np_or_tensor
 
 
-def save_metrics_params(metrics, params):
+def save_metrics_params(metrics: MutableMapping[str, float], params) -> None:
     """Save metrics and parameters and send metrics to the cluster_utils server.
 
     Save the used parameters and resulting metrics to CSV files (filenames defined by
@@ -272,7 +272,8 @@ def save_metrics_params(metrics, params):
     flattened_params = dict(flatten_nested_string_dict(params))
     save_dict_as_one_line_csv(flattened_params, param_file)
 
-    time_elapsed = time.time() - read_params_from_cmdline.start_time
+    time_elapsed = time.time() - read_params_from_cmdline.start_time  # type: ignore
+    time_elapsed = cast(float, time_elapsed)
     if "time_elapsed" not in metrics:
         metrics["time_elapsed"] = time_elapsed
     else:

--- a/cluster_utils/utils.py
+++ b/cluster_utils/utils.py
@@ -18,7 +18,7 @@ import textwrap
 from collections import defaultdict
 from pathlib import Path
 from time import sleep
-from typing import Any
+from typing import Any, Mapping
 
 import colorama
 
@@ -155,7 +155,9 @@ def flatten_nested_string_dict(nested_dict, prepend=""):
             yield prepend + str(key), value
 
 
-def save_dict_as_one_line_csv(dct, filename):
+def save_dict_as_one_line_csv(
+    dct: Mapping[str, float], filename: str | os.PathLike
+) -> None:
     with open(filename, "w") as f:
         writer = csv.DictWriter(f, fieldnames=dct.keys())
         writer.writeheader()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,18 @@
+*************
+API Reference
+*************
+
+The following functions may be used in your job scripts that are executed via
+cluster_utils.
+
+.. autofunction:: cluster_utils.read_params_from_cmdline
+
+.. autofunction:: cluster_utils.save_metrics_params
+
+.. autofunction:: cluster_utils.exit_for_resume
+
+.. autofunction:: cluster_utils.announce_early_results
+
+.. autofunction:: cluster_utils.announce_fraction_finished
+
+.. autofunction:: cluster_utils.cluster_main

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,3 +16,7 @@ cluster_utils.
 .. autofunction:: cluster_utils.announce_fraction_finished
 
 .. autofunction:: cluster_utils.cluster_main
+
+
+.. automodule:: cluster_utils.constants
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ import sphinx.domains.python
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "myst_parser",
     "sphinx_immaterial",

--- a/docs/examples/cluster_main_decorator.rst
+++ b/docs/examples/cluster_main_decorator.rst
@@ -1,0 +1,22 @@
+.. _example_cluster_main_decorator:
+
+************************************
+Using the ``cluster_main`` Decorator
+************************************
+
+This is an example how to use the :func:`~cluster_utils.cluster_main` decorator.
+
+
+.. literalinclude:: ../../examples/basic/main_with_decorator.py
+
+
+The corresponding cluster_utils config file:
+
+.. literalinclude:: ../../examples/basic/grid_search_main_w_decorator.json
+
+
+.. note::
+
+   This example is included in ``cluster_utils/examples/basic`` and can be
+   directly run from there.
+

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -7,3 +7,4 @@ Examples
 
    slurm_timeout_signal.rst
    checkpointing.rst
+   cluster_main_decorator.rst

--- a/docs/exit_for_resume.rst
+++ b/docs/exit_for_resume.rst
@@ -34,14 +34,14 @@ So the high level structure of a job script using
    the job by calling :func:`~cluster_utils.exit_for_resume`.
 
 
+.. hint::
+
+   It may be useful to report intermediate results using
+   :func:`~cluster_utils.announce_early_results` before exiting for resume.
+
+
 Usage Examples
 ==============
 
 - :ref:`example_checkpointing`
 - :ref:`example_slurm_timeout_signal` (combines restarting with Slurm's timeout signal)
-
-
-API
-===
-
-.. autofunction:: cluster_utils.exit_for_resume

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ Documentation Content
    :caption: References
 
    configuration
+   api
    changelog
 
 

--- a/examples/basic/main_with_decorator.py
+++ b/examples/basic/main_with_decorator.py
@@ -43,14 +43,17 @@ def fn_to_optimize(*, u, v, w, x, y, sharp_penalty, tuple_input=None):
 
 @cluster_main
 def main(working_dir, id, **kwargs):  # noqa A002
-    # All parameters in grid_search.json (fixed parameters and the ones searched over)
-    # are passed to main.py as arguments, here caught in <**kwargs>. Could have written
-    # <main(working_dir, id, fn_args, test_resume, ...)>
+    # All parameters in grid_search.json (fixed parameters and the ones
+    # searched over) are passed to main.py as arguments, here caught in
+    # `**kwargs`.
+    # Could have written `main(working_dir, id, fn_args, test_resume, ...)`
     fn_args = kwargs["fn_args"]
     test_resume = kwargs["test_resume"]
+
     # simulate that the jobs take some time
     time.sleep(np.random.randint(0, 10))
     result_file = os.path.join(working_dir, "result.npy")
+
     # here we do a little simulation for checkpointing and resuming
     if os.path.isfile(result_file):
         # If there is a result to resume


### PR DESCRIPTION
Ass sugested in #95, add dedicated page for API documentation.  The idea is to list all functions here, that are supposed to be used by the user.

# TODO
- [ ] I went through examples to figure out which functions are relevent.  Did I miss something?
- [x] Add/extend docstrings of these functions
- [ ] Ideally also add type hints

# Do not merge before
- #95