### PR TITLE
doc: Use custom object type 'confval' for configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,55 +21,82 @@ General Parameters
 These parameters are the same for ``grid_search`` and ``hp_optimization``.
 
 
-- ``optimization_procedure_name`` --- *mandatory*
+.. confval:: optimization_procedure_name
+
+    **Required.**
+
     Name of the setup.
 
-- ``results_dir`` --- *mandatory*
+
+.. confval:: results_dir
+
+    **Required.**
+
     Result files will be written to ``{results_dir}/optimization_procedure_name``.
 
-- ``run_in_working_dir`` --- *optional, default=false*
-    If true, ``git_params`` are ignored and the script specified in
-    ``script_relative_path`` is expected to be in the current working directory.
-    Otherwise see ``git_params``.
+.. confval:: run_in_working_dir = false
 
-- ``git_params`` --- *optional*
-    If ``run_in_working_dir`` is false, the specified git repository is cloned to the
-    job directory and the script specified in ``script_relative_path`` is expected to be
-    found there.
+    If true, :confval:`git_params` are ignored and the script specified in
+    :confval:`script_relative_path` is expected to be in the current working directory.
+    Otherwise see :confval:`git_params`.
 
-    - ``branch``: The git branch to use.
-    - ``commit`` --- *optional*: Hash of a specific commit that should be used.
+.. confval:: git_params
 
-      Note: The current implementation still needs a valid branch to be set as it first
-      clones the repo using that branch and only afterwards checks out the specified
-      commit.
-    - ``url`` --- *optional*: URL to the repo.  If not set, the application
-      expects the current working directory to be inside a git repository
-      and uses the origin URL of this repo.
-    - ``depth`` --- *optional, int*: Create a shallow clone with a history truncated to
-      the specified number of commits. 
-    - ``remove_local_copy`` --- *optional, bool, default=true*: Remove the local working
-      copy when finished.
+    If :confval:`run_in_working_dir` is false, the specified git repository is cloned to
+    the job directory and the script specified in :confval:`script_relative_path` is
+    expected to be found there.
 
-- ``script_relative_path`` --- *mandatory*
-    Python script that is executed.  If ``run_in_working_dir=true``, the path is
-    resolved relative to the working directory, otherwise relative to the root of the
-    git repository specified in ``git_params``.
+    .. confval:: git_params.branch: str
 
-- ``remove_jobs_dir`` --- *optional, bool, default=true*
+        The git branch to use.
+
+    .. confval:: git_params.commit
+
+        Hash of a specific commit that should be used.
+
+        Note: The current implementation still needs a valid branch to be set as it first
+        clones the repo using that branch and only afterwards checks out the specified
+        commit.
+
+    .. confval:: git_params.url
+
+        URL to the repo.  If not set, the application expects the current working
+        directory to be inside a git repository and uses the origin URL of this repo.
+
+    .. confval:: git_params.depth: int
+
+        Create a shallow clone with a history truncated to the specified number of
+        commits. 
+
+    .. confval:: git_params.remove_local_copy: bool = true
+
+        Remove the local working copy when finished.
+
+.. confval:: script_relative_path
+
+    **Required.**
+
+    Python script that is executed.  If :confval:`run_in_working_dir` = true, the path
+    is resolved relative to the working directory, otherwise relative to the root of the
+    git repository specified in :confval:`git_params`.
+
+.. confval:: remove_jobs_dir: bool = true
+
     Whether to remove the data stored in ``${HOME}/.cache`` once finished or not.  Note
     that when running on the cluster this directory also contains the stdout/stderr of
     the jobs (but not when running locally).
 
-- ``remove_working_dirs`` --- *optional, bool, default={grid_search: false, hp_optimization: true}*
+.. confval:: remove_working_dirs: bool = {grid_search: false, hp_optimization: true}
+
     Remove the working directories of the jobs (including the parameters used for that
     job, saved metrics and potentially other output files like checkpoints) once they
     are finished.
 
     For *hp_optimization* the directories of the best jobs kept independent of this
-    setting, see ``num_best_jobs_whose_data_is_kept``.
+    setting, see :confval:`num_best_jobs_whose_data_is_kept`.
 
-- ``generate_report`` --- *optional, default="never"*
+.. confval:: generate_report: str = "never"
+
     Specifies whether a report should be generated automatically. Can be one of the
     following values:
 
@@ -85,33 +112,56 @@ These parameters are the same for ``grid_search`` and ``hp_optimization``.
     *Added in version 3.0.  Set to "every_iteration" to get the behaviour of versions
     <=2.5*
 
-- ``environment_setup`` --- *mandatory*
+.. confval:: environment_setup
+
+    **Required.**
+
     Note: while the ``environment_setup`` argument itself is mandatory, all its
     content are optional (i.e. it can be empty).
 
-    - ``pre_job_script`` --- *str*:  Path to an executable (e.g. bash script)
-      that is executed before the main script runs.
-    - ``virtual_env_path`` --- *str*:  Path of folder of virtual environment
-      to activate.
-    - ``conda_env_path`` --- *str*:  Name of conda environment to activate
-      (this option might be broken).
-    - ``variables`` --- *dict[str]*:  Environment variables to set. Variables
-      are set after a virtual/conda environment is activated, thus override
-      environment variables set before.
-    - ``is_python_script`` --- *bool, default=true*:  Whether the target to run
-      is a Python script.
-    - ``run_as_module`` --- *bool, default=false*:  Whether to run the script as
-      a Python module (``python -m my_package.my_module``) or as a script
-      (``python my_package/my_module.py``).
+    .. confval:: environment_setup.pre_job_script: str:
 
-- ``cluster_requirements`` --- *mandatory*
+        Path to an executable (e.g. bash script) that is executed before the main script
+        runs.
+
+    .. confval:: environment_setup.virtual_env_path: str:
+
+        Path of folder of virtual environment to activate.
+
+    .. confval:: environment_setup.conda_env_path: str:
+
+        Name of conda environment to activate (this option might be broken).
+
+    .. confval:: environment_setup.variables: dict[str]:
+
+        Environment variables to set. Variables are set after a virtual/conda
+        environment is activated, thus override environment variables set before.
+
+    .. confval:: environment_setup.is_python_script: bool, default=true:
+
+        Whether the target to run is a Python script.
+
+    .. confval:: environment_setup.run_as_module: bool, default=false:
+
+        Whether to run the script as a Python module
+        (``python -m my_package.my_module``) or as a script
+        (``python my_package/my_module.py``).
+
+.. confval:: cluster_requirements
+
+    **Required.**
+
     Settings for the cluster (number of CPUs, bid, etc.).  See
     :ref:`config_cluster_requirements`.
 
-- ``singularity`` --- *optional*
+.. confval:: singularity
+
     See :ref:`config_singularity`.
 
-- ``fixed_params`` - *mandatory*
+.. confval:: fixed_params
+
+    **Required.**
+
     TODO
 
 
@@ -122,7 +172,8 @@ Cluster Requirements
 
 When running on a cluster, you have to specify the resources needed for each job (number
 of CPUs/GPUs, memory, etc.).  This is all configured in the section
-``cluster_requirements``.  
+:confval:`cluster_requirements`.  
+
 .. note:: The cluster requirements are ignored when running on a local machine.
 
 Some of the options are common among all supported cluster systems, some are
@@ -136,23 +187,27 @@ Simple example (in TOML):
    [cluster_requirements]
    request_cpus = 1
    request_gpus = 0
-   memory_in_mb = 1_000
-   bid = 1_000
+   memory_in_mb = 1000
+   bid = 1000
 
 
 Common Options
 ~~~~~~~~~~~~~~
 
-- ``request_cpus`` --- *int*
+.. confval:: cluster_requirements.request_cpus: int
+
     Number of CPUs that is requested.
 
-- ``request_gpus`` --- *int*
+.. confval:: cluster_requirements.request_gpus: int
+
     Number of GPUs that is requested.
 
-- ``memory_in_mb`` --- *int*
+.. confval:: cluster_requirements.memory_in_mb: int
+
     Memory (in MB) that is requested.
 
-- ``forbidden_hostnames`` --- *list[str]*
+.. confval:: cluster_requirements.forbidden_hostnames: list[str]
+
     Cluster nodes to exclude from running jobs. Useful if nodes are malfunctioning.
 
 
@@ -161,11 +216,13 @@ Condor-specific Options
 
 The following options are only used when running on Condor (i.e. the MPI cluster).
 
-- ``bid`` --- *int*
+.. confval:: cluster_requirements.bid: int
+
     The amount of cluster money you are bidding for each job.  See documentation of the
     MPI-IS cluster on how the bidding system works.
 
-- ``cuda_requirement`` --- *?*
+.. confval:: cluster_requirements.cuda_requirement
+
     ``cuda_requirement`` has multiple behaviors. If it is a number, it specifies the
     *minimum* CUDA capability the GPU should have. If the number is prefixed with ``<``
     or ``<=``, it specifies the *maximum* CUDA capability. Otherwise, the value is taken
@@ -182,10 +239,12 @@ The following options are only used when running on Condor (i.e. the MPI cluster
     https://atlas.is.localnet/confluence/display/IT/Specific+GPU+needs for the kind
     of constraints that are possible.
 
-- ``gpu_memory_mb`` --- *int*
+.. confval:: cluster_requirements.gpu_memory_mb: int
+
     Minimum memory size the GPU should have, in megabytes.
 
-- ``concurrency_limit`` / ``concurrency_limit_tag`` --- *optional*
+.. confval:: cluster_requirements.concurrency_limit
+
     Limit the number of concurrent jobs. You can assign a resource (tag) to your jobs
     and specify how many tokens each jobs consumes. There is a total of 10,000 tokens
     per resource. If you want to run 10 concurrent jobs, each job has to consume
@@ -206,10 +265,16 @@ The following options are only used when running on Condor (i.e. the MPI cluster
     You can assign different tags to different runs. In that way you can limit only
     the number of gpu jobs, for instance.
 
-- ``hostname_list`` --- *list[str]*
+.. confval:: cluster_requirements.concurrency_limit_tag
+
+    See :confval:`cluster_requirements.concurrency_limit`
+
+.. confval:: cluster_requirements.hostname_list: list[str]
+
     Cluster nodes to exclusively use for running jobs.
 
-- ``extra_submission_options`` --- *dict | list | str*
+.. confval:: cluster_requirements.extra_submission_options: dict | list | str
+
     This allows to add additional lines to the `.sub` file used for submitting jobs to
     the cluster. Note that this setting is normally not needed, as cluster_utils
     automatically builds the submission file for you.
@@ -221,14 +286,21 @@ The following options are only used when running on Condor (i.e. the MPI cluster
 Slurm-specific Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- ``partition`` --- *mandatory, str*
+.. confval:: cluster_requirements.partition: str
+
+    **Required.**
+
     Name of the partition to run the jobs on.  See documentation of the corresponding
     cluster on what partitions are available.
 
     Multiple partitions can be given as a comma-separated string
     (``partition1,partition2``), in this case jobs will be executed on any of them
     (depending on which has free capacity first).
-- ``request_time`` --- *mandatory, str*
+
+.. confval:: cluster_requirements.request_time: str
+
+    **Required.**
+
     Time limit for the jobs.  Jobs taking longer than this will be aborted, so make
     sure to request enough time (but don't exaggerate too much as shorter jobs can be
     scheduled more easily).
@@ -240,12 +312,15 @@ Slurm-specific Options
         "days-hours:minutes:seconds".
 
     So for example to request 1 hour per job use ``request_time = "1:00:00"``.
-- ``signal_seconds_to_timeout`` --- *int*
+
+.. confval:: cluster_requirements.signal_seconds_to_timeout: int
+
     Time in seconds before timeout at which Slurm sends a USR1 signal to the job (see
     ``--signal`` of ``sbatch``).  If not set, no signal is sent.
 
     See example :doc:`examples/slurm_timeout_signal`.
-- ``extra_submission_options`` --- *list[str]*
+.. confval:: cluster_requirements.extra_submission_options: list[str]
+
     List of additional options for ``sbatch``.  Can be used if a specific
     setting is needed which is not already covered by the options above.
     Expects a list with arguments as they are passed to ``sbatch``, for example:
@@ -272,25 +347,31 @@ Use Singularity/Apptainer Containers
 
 Jobs can be executed inside Singularity/Apptainer [#singularity1]_ containers to give
 you full control over the environment, installed packages, etc.  To enable
-containerisation of jobs, add a section ``singularity`` in the config file.  This
+containerisation of jobs, add a section :confval:`singularity` in the config file.  This
 section can have the following parameters:
 
 
-- ``image`` --- *mandatory*
+.. confval:: singularity.image
+
+    **Required.**
+
     Path to the container image.
 
-- ``executable`` --- *default="singularity"*
+.. confval:: singularity.executable: str = "singularity"
+
     Specify the executable that is used to run the container (mostly useful if you want
     to explicitly use Apptainer instead of Singularity in an environment where both are
     installed).
 
-- ``use_run`` --- *default=false*
+.. confval:: singularity.use_run: bool = false
+
     Per default the container is run with ``singularity exec``.  Set this to true to use
     ``singularity run`` instead.  This is only useful for images that use a wrapper run
     script that executes the given command (sometimes needed for some environment
     initialisation).
 
-- ``args`` --- *default=[]*
+.. confval:: singularity.args: list[str] = []
+
     List of additional arguments that are passed to ``singularity exec|run``.  Use this
     to set flags like ``--nv``, ``--cleanenv``, ``--contain``, etc. if needed.
 
@@ -307,17 +388,25 @@ Example (in TOML):
 Specific for hp_optimization
 ============================
 
-- ``num_best_jobs_whose_data_is_kept`` --- *mandatory, int*
+.. confval:: num_best_jobs_whose_data_is_kept: int
+
+    **Required.**
+
     Keep copies of the working directories of the given number of best jobs.  They are
     stored in ``{results_dir}/best_jobs/``.
 
-- ``kill_bad_jobs_early`` --- *optional, bool, default=false*
+.. confval:: kill_bad_jobs_early: bool = false
+
     TODO
 
-- ``early_killing_params`` --- *optional*
+.. confval:: early_killing_params
+
     TODO
 
-- ``optimizer_str`` --- *mandatory*
+.. confval:: optimizer_str
+
+    **Required.**
+
     The optimisation method that is used to find good hyperparameters.
     Supported methods are 
 
@@ -328,15 +417,24 @@ Specific for hp_optimization
     \* To use nevergrad, the optional dependencies from the "nevergrad" group are
     needed, see :ref:`optional_dependencies`.
 
-- ``optimizer_settings`` --- *mandatory*
-    Settings specific to the optimiser selected in ``optimizer_str``. See
+.. confval:: optimizer_settings
+
+    **Required.**
+
+    Settings specific to the optimiser selected in :confval:`optimizer_str`. See
     :ref:`config.optimizer_settings`.
 
-- ``optimization_setting`` --- *mandatory*
+.. confval:: optimization_setting
+
+    **Required.**
+
     General settings for the optimisation (independent of the optimisation method).  See
     :ref:`config.optimization_settings`.
 
-- ``optimized_params`` --- *mandatory*
+.. confval:: optimized_params
+
+    **Required.**
+
     Defines the parameters that are optimised over.  Expectes a list
     of dictionaries with each entry having the following elements:
 
@@ -386,31 +484,45 @@ Specific for hp_optimization
 General Optimisation Settings
 -----------------------------
 
-The ``optimization_setting`` parameter defines the general optimisation
+The :confval:`optimization_setting` parameter defines the general optimisation
 settings (i.e. the ones independent of the optimisation method set in
-``optimizer_str``).  A dictionary with the following values is expected:
+:confval:`optimizer_str`).  A dictionary with the following values is expected:
 
 
-- ``metric_to_optimize`` --- *mandatory, str*
+.. confval:: optimization_setting.metric_to_optimize: str
+
+    **Required.**
+
     Name of the metric that is used for the optimisation.  Has to match the name of one
     of the metrics that are saved with :func:`cluster_utils.save_metrics_params`.
 
-- ``minimize`` --- *mandatory, bool*
+.. confval:: optimization_setting.minimize: bool
+
+    **Required.**
+
     Specify whether the metric shall be minimized (true) or maximised (false).
 
-- ``number_of_samples`` --- *mandatory, int*
+.. confval:: optimization_setting.number_of_samples: int
+
+    **Required.**
+
     The total number of jobs that will be run.
 
-- ``n_jobs_per_iteration`` --- *mandatory, int*
+.. confval:: optimization_setting.n_jobs_per_iteration: int
+
+    **Required.**
+
     The number of jobs submitted to the cluster concurrently, and also the number of
     finished jobs per report iteration.
 
-- ``n_completed_jobs_before_resubmit`` --- *optional, int, default=1*
+.. confval:: optimization_setting.n_completed_jobs_before_resubmit: int = 1
+
     The number of jobs that have to be finished before another
     ``n_completed_jobs_before_resubmit`` jobs are submitted.  Defaults to 1 (i.e. submit
     new job immediately when one finishes).
 
-- ``run_local`` --- *optional, bool*
+.. confval:: optimization_setting.run_local: bool
+
     Specify if the optimisation shall be run locally if the cluster is not detected.  If
     not set, the user will be asked at runtime in this case.
 
@@ -421,12 +533,13 @@ About Iterations
 The exact meaning of one "iteration" of the hp_optimization mode is a bit
 complicated and depends on the configuration.
 
-Relevant are the following parameters from the ``optimization_setting``
+Relevant are the following parameters from the :confval:`optimization_setting`
 section:
 
-- ``number_of_samples``
-- ``n_jobs_per_iteration``
-- ``n_completed_jobs_before_resubmit`` (default: 1)
+- :confval:`optimization_setting.number_of_samples`
+- :confval:`optimization_setting.n_jobs_per_iteration`
+- :confval:`optimization_setting.n_completed_jobs_before_resubmit`  (default: 1)
+
 
 ``number_of_samples`` is simply the total number of jobs that are run.
 ``n_jobs_per_iteration`` says how many jobs can be executed in parallel.
@@ -461,13 +574,16 @@ Optimizer Settings
 ------------------
 
 ``optimizer_settings`` expects as value a dictionary with configuration specific
-to the method that is specified in ``optimizer_str``.  Below are the
+to the method that is specified in :confval:`optimizer_str`.  Below are the
 corresponding parameters for each method.
 
 cem_metaoptimizer
 ~~~~~~~~~~~~~~~~~
 
-- ``with_restarts`` --- *mandatory, bool*
+.. confval:: with_restarts: bool
+
+    **Required.**
+
     Whether a specific set of settings can be run multiple times. This can be useful to
     automatically verify if good runs were just lucky runs because of e.g. the random
     seed, making the found solutions more robust.
@@ -476,7 +592,10 @@ cem_metaoptimizer
     After that each new job has a 20% chance to use the same settings as a previous job
     (drawn from the set of best jobs).
 
-- ``num_jobs_in_elite`` --- *mandatory, int*
+.. confval:: num_jobs_in_elite: int
+
+    **Required.**
+
     TODO
 
 
@@ -488,33 +607,39 @@ nevergrad
    To use nevergrad, the optional dependencies from the "nevergrad" group are needed,
    see :ref:`optional_dependencies`.
 
-- ``opt_alg`` --- *mandatory*
-    TODO
+.. confval:: opt_alg
 
-gridsearch
-~~~~~~~~~~
+    **Required.**
 
-- ``restarts`` --- *mandatory*
     TODO
 
 
 Specific for grid_search
 ========================
 
-- ``local_run`` --- *optional*
+.. confval:: local_run
+
     TODO
 
-- ``load_existing_results`` --- *optional, bool, default=false*
+.. confval:: load_existing_results: bool = false
+
     TODO
 
-- ``restarts`` --- *mandatory*
+.. confval:: restarts
+
+    **Required.**
+
     How often to run each configuration (useful if there is some randomness in the
     result).
 
-- ``samples``
-    TODO:  Does not seem to be used in grid_search
+.. confval:: samples
 
-- ``hyperparam_list`` --- *mandatory*
+    TODO
+
+.. confval:: hyperparam_list
+
+    **Required.**
+
     Probably list of parameters over which the grid search is performed.
     List of dicts:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ exclude = ["build/", "examples/"]
 [[tool.mypy.overrides]]
 # list all modules for which no type hints are available
 module = [
+    "docutils.*",
     "matplotlib.*",
     "nevergrad.*",
     "nox",
@@ -51,5 +52,6 @@ module = [
     "setuptools",
     "sklearn.ensemble",
     "smart_settings",  # TODO we can add hints there
+    "sphinx.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
This makes the rendering of the configuration page a bit nicer and, more importantly, allows to link/reference individual parameters.

Parameters can be added with
```rst
.. confval: namespace.foo: type = default_value

   [description]
```
and can be referenced in other parts of the documentation with
```rst
:confval:`namespace.foo`
```
Can probably still be improved a bit (e.g. I'd like to have a better way to mark required parameters) but I think it's already quite an improvement to before.

Example on how it looks like:
![image](https://github.com/martius-lab/cluster_utils/assets/9333121/ed7c5747-222f-4570-a8dc-155197d5d4c0)
