### PR TITLE
Get package version from git and also set `__version__`

### DIFF
--- a/cluster_utils/__init__.py
+++ b/cluster_utils/__init__.py
@@ -1,3 +1,6 @@
+import contextlib
+import importlib.metadata
+
 from .job_manager import grid_search, hp_optimization
 from .settings import (
     announce_early_results,
@@ -7,6 +10,12 @@ from .settings import (
     read_params_from_cmdline,
     save_metrics_params,
 )
+
+# The version is set based on git at install time, so we get it from the metadata of the
+# installed package here.  If this file is imported without the package being installed,
+# this will fail.  In that case, catch the error and do not set __version__ at all.
+with contextlib.suppress(importlib.metadata.PackageNotFoundError):
+    __version__ = importlib.metadata.version(__package__)
 
 __all__ = [
     "grid_search",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "cluster-utils"
-version = "2.5"
+dynamic = ["version"]
 description = "Cluster utilities"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
@@ -34,6 +34,11 @@ dependencies = [
 
 [tool.setuptools]
 packages = ["cluster_utils", "cluster"]
+
+[tool.setuptools_scm]
+# Can be empty if no extra settings are needed, presence enables setuptools_scm.
+# You can check which version it picked by running `python3 -m setuptools_scm` in the
+# package root.
 
 [project.urls]
 Documentation = "https://martius-lab.github.io/cluster_utils"


### PR DESCRIPTION
Use setuptools_scm to automatically set the package version based on git tags.  It seems to be quite nice as it gives accurate versions for development branches.  For example with the last version tag currently being v2.5, I now get something like "2.6.dev254+gdc20c3d.d20240521" as version.

Also define `__version__` in the main package `__init__.py` (resolves #82), using the version obtained with importlib (i.e. will use the version that was inferred by setuptools_scm during installation).

## Do not merge before
- #101 