### PR TITLE
Rename read_params_from_cmdline and save_metrics_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local submissions now store stdout and stderr to log files, like they would do on the cluster.
   This should be useful for debugging scripts to work with the cluster locally, as previously,
   there was no way to access the outputs of locally running jobs.
+- Renamed `read_params_from_cmdline` to `initialize_job`.  An alias with the old name is
+  available but will raise a FutureWarning.
+- Renamed `save_metrics_params` to `finalize_job`.  An alias with the old name is
+  available but will raise a FutureWarning.
 - *Relevant for Dev's only:* Use ruff instead of flake8 for linting.
+
+### Removed
+- Removed option `save_params` from `read_params_from_cmdline`.  They will always be
+  saved now.
+- Removed option `make_immutable` from `read_params_from_cmdline`.  Returned parameters
+  are always immutable now.  If needed, a mutable copy can be created with
+  `smart_settings.param_classes.AttributeDict(params)`.
 
 ### Added
 - Setting `generate_report` to control automatic report generation (See
@@ -86,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The package has been renamed from "cluster" to "cluster_utils", please update your
   imports accordingly.  There is still a wrapper package with the old name (so existing
   code should still work) but it will be removed in the next major release.
+- `read_params_from_cmdline` is deprecated.  Use `initialize_job` instead.
+- `save_metrics_params` is deprecated.  Use `finalize_job` instead.
 
 
 ## 2.5 - 2023-10-05

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ def main(
 If you don't want to use a decorator, use the following:
 
 ```python
-from cluster_utils import read_params_from_cmdline, save_metrics_params
+import cluster_utils
 
 def main(params):
     results = ...  # Code that computes something interesting
@@ -81,12 +81,12 @@ def main(params):
 if __name__ == "__main__":
     # Dictionary that contains parameters passed by cluster_utils. This call also establishes 
     # communication with the cluster_utils server. Also contains "working_dir" and "id", as above.
-    params = read_params_from_cmdline()
+    params = cluster_utils.initialize_job()
 
     results = main(params)
 
     # Report results back to cluster_utils.
-    save_metrics_params(results)
+    cluster_utils.finalize_job(results)
 ```
 
 To start a cluster run, start the cluster_utils server on the login node of the cluster.

--- a/cluster_utils/__init__.py
+++ b/cluster_utils/__init__.py
@@ -6,6 +6,8 @@ from .client import (
     announce_fraction_finished,
     cluster_main,
     exit_for_resume,
+    finalize_job,
+    initialize_job,
     read_params_from_cmdline,
     save_metrics_params,
 )
@@ -24,6 +26,8 @@ __all__ = [
     "announce_fraction_finished",
     "cluster_main",
     "exit_for_resume",
+    "finalize_job",
+    "initialize_job",
     "save_metrics_params",
     "read_params_from_cmdline",
 ]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -497,7 +497,7 @@ settings (i.e. the ones independent of the optimisation method set in
     **Required.**
 
     Name of the metric that is used for the optimisation.  Has to match the name of one
-    of the metrics that are saved with :func:`cluster_utils.save_metrics_params`.
+    of the metrics that are saved with :func:`~cluster_utils.client.finalize_job`.
 
 .. confval:: optimization_setting.minimize: bool
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -8,7 +8,7 @@ Below is a list of error messages that may occur with potential solutions.
 
 **Pandas DataError: No numeric types to aggregate**
 
-If one of the values stored with :func:`~cluster_utils.save_metrics_params` has a
+If one of the values stored with :func:`~cluster_utils.client.finalize_job` has a
 non-numeric type (e.g. string).
 
 

--- a/examples/basic/main.py
+++ b/examples/basic/main.py
@@ -3,7 +3,7 @@ import time
 
 import numpy as np
 
-from cluster_utils import exit_for_resume, read_params_from_cmdline, save_metrics_params
+from cluster_utils import exit_for_resume, finalize_job, initialize_job
 
 
 def fn_to_optimize(*, u, v, w, x, y, sharp_penalty, tuple_input=None):
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     if np.random.rand() < 0.05:
         raise ValueError("5 percent of all jobs die early for testing")
 
-    params = read_params_from_cmdline()
+    params = initialize_job()
 
     # simulate that the jobs take some time
     max_sleep_time = params.get("max_sleep_time", 10)
@@ -68,5 +68,5 @@ if __name__ == "__main__":
 
     noisy_result = noiseless_result + 0.5 * np.random.normal()
     metrics = {"result": noisy_result, "noiseless_result": noiseless_result}
-    save_metrics_params(metrics, params)
+    finalize_job(metrics, params)
     print(noiseless_result)

--- a/examples/basic/main_no_fail.py
+++ b/examples/basic/main_no_fail.py
@@ -5,7 +5,7 @@ import time
 
 import numpy as np
 
-from cluster_utils import exit_for_resume, read_params_from_cmdline, save_metrics_params
+from cluster_utils import exit_for_resume, finalize_job, initialize_job
 
 
 def fn_to_optimize(*, u, v, w, x, y, sharp_penalty, tuple_input=None):
@@ -41,7 +41,7 @@ def fn_to_optimize(*, u, v, w, x, y, sharp_penalty, tuple_input=None):
 
 
 if __name__ == "__main__":
-    params = read_params_from_cmdline()
+    params = initialize_job()
 
     # simulate that the jobs take some time
     max_sleep_time = params.get("max_sleep_time", 10)
@@ -63,5 +63,5 @@ if __name__ == "__main__":
 
     noisy_result = noiseless_result + 0.5 * np.random.normal()
     metrics = {"result": noisy_result, "noiseless_result": noiseless_result}
-    save_metrics_params(metrics, params)
+    finalize_job(metrics, params)
     print(noiseless_result)

--- a/examples/checkpointing/checkpoint_example.py
+++ b/examples/checkpointing/checkpoint_example.py
@@ -5,8 +5,8 @@ import torch
 
 from cluster_utils import (
     exit_for_resume,
-    read_params_from_cmdline,
-    save_metrics_params,
+    finalize_job,
+    initialize_job,
 )
 
 
@@ -41,7 +41,7 @@ def load_checkpoint(load_path, model, optim):
 
 if __name__ == "__main__":
     # parameters are loaded from json file
-    params = read_params_from_cmdline()
+    params = initialize_job()
     # a folder for each run is created
     os.makedirs(params.working_dir, exist_ok=True)
     checkpoint_path = os.path.join(params.working_dir, "checkpoint.pt")
@@ -88,5 +88,5 @@ if __name__ == "__main__":
 
     metrics = {"loss": loss, "iterations": iteration}
     # save final metrics, you will only see the resuming in the cluster_run.log file
-    save_metrics_params(metrics, params)
+    finalize_job(metrics, params)
     print(f"Training finished, final loss {loss} at episode {iteration}")

--- a/examples/slurm_timeout_signal/main.py
+++ b/examples/slurm_timeout_signal/main.py
@@ -21,7 +21,7 @@ def timeout_signal_handler(sig, frame):
 
 def main() -> int:
     """Main function."""
-    params = cluster_utils.read_params_from_cmdline()
+    params = cluster_utils.initialize_job()
 
     n_training_iterations = 60
     start_iteration = 0
@@ -53,7 +53,7 @@ def main() -> int:
 
     # just return some dummy metric value here
     metrics = {"result": params.x + params.y, "n_iterations": i}
-    cluster_utils.save_metrics_params(metrics, params)
+    cluster_utils.finalize_job(metrics, params)
 
     return 0
 

--- a/tests/main_no_save_metrics.py
+++ b/tests/main_no_save_metrics.py
@@ -1,9 +1,9 @@
 import time
 
-from cluster_utils import read_params_from_cmdline
+from cluster_utils import initialize_job
 
 if __name__ == "__main__":
-    params = read_params_from_cmdline()
+    params = initialize_job()
     time.sleep(2)
     # Here we exit without sending result to cluster utils. We want cluster utils to count the job
     # as failed.

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -14,157 +14,159 @@ def tests_dir() -> pathlib.Path:
     return pathlib.Path(__file__).parent
 
 
-def test_read_params_from_cmdline__dict():
-    argv = ["test", "--parameter-dict", "{'foo': 'bar', 'one': {'two': 13}}"]
-    params = client.read_params_from_cmdline(cmd_line=argv)
+# Run all tests with both initialize_job() and its alias read_params_from_cmdline
+@pytest.mark.parametrize(
+    "initialize_job",
+    [client.initialize_job, client.read_params_from_cmdline],
+)
+class TestInitializeJob:
 
-    assert "foo" in params
-    assert "one" in params
-    assert "two" in params["one"]
-    assert params["foo"] == "bar"
-    assert params["one"]["two"] == 13
+    def test_initialize_job__dict(self, initialize_job):
+        argv = ["test", "--parameter-dict", "{'foo': 'bar', 'one': {'two': 13}}"]
+        params = initialize_job(cmd_line=argv)
 
+        assert "foo" in params
+        assert "one" in params
+        assert "two" in params["one"]
+        assert params["foo"] == "bar"
+        assert params["one"]["two"] == 13
 
-def test_read_params_from_cmdline__dict_and_overwrite():
-    argv = [
-        "test",
-        "--parameter-dict",
-        "{'foo': 'bar', 'one': {'two': 13}}",
-        "foo='blub'",
-        "three=3",
-    ]
-    params = client.read_params_from_cmdline(cmd_line=argv)
+    def test_initialize_job__dict_and_overwrite(self, initialize_job):
+        argv = [
+            "test",
+            "--parameter-dict",
+            "{'foo': 'bar', 'one': {'two': 13}}",
+            "foo='blub'",
+            "three=3",
+        ]
+        params = initialize_job(cmd_line=argv)
 
-    assert "foo" in params
-    assert params["foo"] == "blub"
-    assert "one" in params
-    assert "two" in params["one"]
-    assert params["one"]["two"] == 13
-    assert "three" in params
-    assert params["three"] == 3
+        assert "foo" in params
+        assert params["foo"] == "blub"
+        assert "one" in params
+        assert "two" in params["one"]
+        assert params["one"]["two"] == 13
+        assert "three" in params
+        assert params["three"] == 3
 
+    def test_initialize_job__file(self, initialize_job, tmp_path):
+        # save config to file
+        config_file = tmp_path / "config.json"
+        with open(config_file, "w") as f:
+            json.dump({"foo": "bar", "one": {"two": 13}}, f)
 
-def test_read_params_from_cmdline__file(tmp_path):
-    # save config to file
-    config_file = tmp_path / "config.json"
-    with open(config_file, "w") as f:
-        json.dump({"foo": "bar", "one": {"two": 13}}, f)
+        argv = ["test", str(config_file)]
+        params = initialize_job(cmd_line=argv)
 
-    argv = ["test", str(config_file)]
-    params = client.read_params_from_cmdline(cmd_line=argv)
+        assert "foo" in params
+        assert "one" in params
+        assert "two" in params["one"]
+        assert params["foo"] == "bar"
+        assert params["one"]["two"] == 13
 
-    assert "foo" in params
-    assert "one" in params
-    assert "two" in params["one"]
-    assert params["foo"] == "bar"
-    assert params["one"]["two"] == 13
+    def test_initialize_job__file_and_overwrite(self, initialize_job, tmp_path):
+        # save config to file
+        config_file = tmp_path / "config.json"
+        with open(config_file, "w") as f:
+            json.dump({"foo": "bar", "one": {"two": 13}}, f)
 
+        argv = [
+            "test",
+            str(config_file),
+            "foo='blub'",
+            "three=3",
+        ]
+        params = initialize_job(cmd_line=argv)
 
-def test_read_params_from_cmdline__file_and_overwrite(tmp_path):
-    # save config to file
-    config_file = tmp_path / "config.json"
-    with open(config_file, "w") as f:
-        json.dump({"foo": "bar", "one": {"two": 13}}, f)
+        assert "foo" in params
+        assert params["foo"] == "blub"
+        assert "one" in params
+        assert "two" in params["one"]
+        assert params["one"]["two"] == 13
+        assert "three" in params
+        assert params["three"] == 3
 
-    argv = [
-        "test",
-        str(config_file),
-        "foo='blub'",
-        "three=3",
-    ]
-    params = client.read_params_from_cmdline(cmd_line=argv)
+    def test_initialize_job__errors(self, initialize_job, monkeypatch):
+        # for better testability, overwrite the ArgumentParser.error method with one that
+        # raises an error instead of exiting
+        def monkey_error(self, message):
+            raise RuntimeError(message)
 
-    assert "foo" in params
-    assert params["foo"] == "blub"
-    assert "one" in params
-    assert "two" in params["one"]
-    assert params["one"]["two"] == 13
-    assert "three" in params
-    assert params["three"] == 3
+        monkeypatch.setattr(argparse.ArgumentParser, "error", monkey_error)
 
+        argv = [
+            "test",
+            "{'foo': 13}",  # not a file
+        ]
+        with pytest.raises(
+            FileNotFoundError,
+            match=re.escape("'{'foo': 13}' does not exist or is not a file."),
+        ):
+            initialize_job(cmd_line=argv)
 
-def test_read_params_from_cmdline__errors(monkeypatch):
-    # for better testability, overwrite the ArgumentParser.error method with one that
-    # raises an error instead of exiting
-    def monkey_error(self, message):
-        raise RuntimeError(message)
+        argv = [
+            "test",
+            "--job-id=42",
+            "--cluster-utils-server=invalid_format",
+            "--parameter-dict",
+            "{'foo': 13}",
+        ]
+        with pytest.raises(RuntimeError, match="--cluster-utils-server"):
+            initialize_job(cmd_line=argv)
 
-    monkeypatch.setattr(argparse.ArgumentParser, "error", monkey_error)
+        argv = [
+            "test",
+            "--cluster-utils-server=127.0.0.1:12345",
+            "--parameter-dict",
+            "{'foo': 13}",
+        ]
+        with pytest.raises(
+            RuntimeError,
+            match="--job-id is required when --cluster-utils-server is set",
+        ):
+            initialize_job(cmd_line=argv)
 
-    argv = [
-        "test",
-        "{'foo': 13}",  # not a file
-    ]
-    with pytest.raises(
-        FileNotFoundError,
-        match=re.escape("'{'foo': 13}' does not exist or is not a file."),
-    ):
-        client.read_params_from_cmdline(cmd_line=argv)
+        argv = ["test", "--parameter-dict", "'notadictionary'"]
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "'parameter_file_or_dict' must be a dictionary (`--parameter-dict` is set)."
+            ),
+        ):
+            initialize_job(cmd_line=argv)
 
-    argv = [
-        "test",
-        "--job-id=42",
-        "--cluster-utils-server=invalid_format",
-        "--parameter-dict",
-        "{'foo': 13}",
-    ]
-    with pytest.raises(RuntimeError, match="--cluster-utils-server"):
-        client.read_params_from_cmdline(cmd_line=argv)
+    def test_initialize_job__working_dir(self, initialize_job, tmp_path):
+        # Add "working_dir" to config
+        working_dir = tmp_path / "working_dir"
+        working_dir.mkdir()
 
-    argv = [
-        "test",
-        "--cluster-utils-server=127.0.0.1:12345",
-        "--parameter-dict",
-        "{'foo': 13}",
-    ]
-    with pytest.raises(
-        RuntimeError,
-        match="--job-id is required when --cluster-utils-server is set",
-    ):
-        client.read_params_from_cmdline(cmd_line=argv)
+        base_config = {
+            "test_resume": False,
+            "max_sleep_time": 13,
+            "fn_args.w": 1,
+            "fn_args.x": 3.0,
+            "fn_args.y": 0.1,
+            "fn_args.sharp_penalty": False,
+            "working_dir": str(working_dir),
+        }
 
-    argv = ["test", "--parameter-dict", "'notadictionary'"]
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "'parameter_file_or_dict' must be a dictionary (`--parameter-dict` is set)."
-        ),
-    ):
-        client.read_params_from_cmdline(cmd_line=argv)
+        # save config to file
+        config_file = tmp_path / "config.json"
+        with open(config_file, "w") as f:
+            json.dump(base_config, f)
 
+        cmd_line = ["test", str(config_file)]
+        params = initialize_job(
+            cmd_line,
+            verbose=False,
+        )
 
-def test_read_params_from_cmdline__working_dir(tmp_path):
-    # Add "working_dir" to config
-    working_dir = tmp_path / "working_dir"
-    working_dir.mkdir()
+        # just a basic check to see if the file was read
+        assert params["max_sleep_time"] == 13
 
-    base_config = {
-        "test_resume": False,
-        "max_sleep_time": 13,
-        "fn_args.w": 1,
-        "fn_args.x": 3.0,
-        "fn_args.y": 0.1,
-        "fn_args.sharp_penalty": False,
-        "working_dir": str(working_dir),
-    }
-
-    # save config to file
-    config_file = tmp_path / "config.json"
-    with open(config_file, "w") as f:
-        json.dump(base_config, f)
-
-    cmd_line = ["test", str(config_file)]
-    params = client.read_params_from_cmdline(
-        cmd_line,
-        verbose=False,
-    )
-
-    # just a basic check to see if the file was read
-    assert params["max_sleep_time"] == 13
-
-    # verify that settings file was written
-    output_settings_file = working_dir / constants.JSON_SETTINGS_FILE
-    assert output_settings_file.is_file()
-    with open(output_settings_file, "r") as f:
-        settings = json.load(f)
-    assert settings["max_sleep_time"] == 13
+        # verify that settings file was written
+        output_settings_file = working_dir / constants.JSON_SETTINGS_FILE
+        assert output_settings_file.is_file()
+        with open(output_settings_file, "r") as f:
+            settings = json.load(f)
+        assert settings["max_sleep_time"] == 13


### PR DESCRIPTION
Rename
- `read_params_from_cmdline` to `initialize_job`, and
- `save_metrics_params` to `finalize_job`.

as discussed in https://github.com/martius-lab/cluster_utils/pull/99#discussion_r1634365846

The purpose of the renaming is to better reflect when/why to call the functions instead of focusing too much on technical details, which are likely of less interest to the user.

The old names are kept as aliases but are marked as deprecated.  Using them will trigger a FutureWarning.

BREAKING: I used this occasion to remove the following options from `initialize_job/read_params_from_cmdline`:
- `make_immutable`: Parameters are always immutable now.  If one really needs a mutable structure, this is still possible by copying the data.
- `save_params`: It simply always saves now.

Let me know if you think this is a problem, then I'll undo that part.
Generally, I'd like to remove the direct `smart_settings` options, so the cluster_utils API is not directly dependent on the configuration parser that is used.  `dynamic` is still there, as I wasn't sure what it is doing.  Are there use-cases where one would want to set it to False, or could I remove that as well?

## Do not merge before
- #106 