### PR TITLE
fix: Restrict numpy version to < 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
 dependencies = [
     "colorama",
     "gitpython>=3.0.5",
-    "numpy",
+    "numpy<2",
     "pandas[output_formatting]==2.0.3",
     "pyuv @ git+https://github.com/saghul/pyuv.git@2a3d42d44c6315ebd73899a35118380d2d5979b5",
     "scipy",


### PR DESCRIPTION
NumPy 2 got released, which is unfortunately not compatible with pandas 2.0.3, which we depend on specifically.
As quick fix for now simply restrict to numpy < 2.

This is just for making the currently broken installation work again.  Generally, we should decide how we handle dependency versions but I'll open a separate issue for that.