### PR TITLE
Documentation: Several small fixes and improvments

### DIFF
--- a/cluster_utils/client/__init__.py
+++ b/cluster_utils/client/__init__.py
@@ -2,9 +2,9 @@
 
 The cluster_utils client API is used in the job scripts implemented by the user and are
 used to communicate with the cluster_utils server process.  Most important are
-:func:`read_params_from_cmdline`, which has to be called in the beginning to register
-with the server, and :func:`save_metrics_params`, which is called in the end to
-send the results in the end.
+:func:`initialize_job`, which has to be called in the beginning to register with the
+server, and :func:`finalize_job`, which is called in the end to send the results in the
+end.
 """
 
 from __future__ import annotations
@@ -278,7 +278,7 @@ def finalize_job(metrics: MutableMapping[str, float], params) -> None:
     Args:
         metrics:  Dictionary with metrics that should be sent to the server.
         params:  Parameters that were used to run the job (given by
-            :func:`read_params_from_cmdline`).
+            :func:`initialize_job`).
     """
     param_file = os.path.join(params.working_dir, constants.CLUSTER_PARAM_FILE)
     flattened_params = dict(flatten_nested_string_dict(params))
@@ -374,11 +374,11 @@ def cluster_main(main_func=None, **read_params_args):
     """Decorator for your main function to automatically register with cluster_utils.
 
     Use this as a decorator to automatically wrap a function (usually ``main``) with
-    calls to :func:`read_params_from_cmdline` and :func:`save_metrics_params`.
+    calls to :func:`initialize_job` and :func:`finalize_job`.
 
-    The parameters read by :func:`read_params_from_cmdline` will be passed as kwargs to
-    the function.  Further, the function is expected to return the metrics dictionary as
-    expected by :func:`save_metrics_params`.
+    The parameters read by :func:`initialize_job` will be passed as kwargs to the
+    function.  Further, the function is expected to return the metrics dictionary as
+    expected by :func:`finalize_job`.
 
     See :ref:`example_cluster_main_decorator` for an usage example.
     """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,12 +2,15 @@
 API Reference
 *************
 
+Job Script API
+==============
+
 The following functions may be used in your job scripts that are executed via
 cluster_utils.
 
-.. autofunction:: cluster_utils.read_params_from_cmdline
+.. autofunction:: cluster_utils.initialize_job
 
-.. autofunction:: cluster_utils.save_metrics_params
+.. autofunction:: cluster_utils.finalize_job
 
 .. autofunction:: cluster_utils.exit_for_resume
 
@@ -18,5 +21,24 @@ cluster_utils.
 .. autofunction:: cluster_utils.cluster_main
 
 
+Output Filenames
+================
+
+The constants listed below define names of output files that are written by
+cluster_utils.  They are listed here, so that other parts of the documentation can
+reference them.
+
 .. automodule:: cluster_utils.constants
    :members:
+
+
+Deprecated API
+==============
+
+The following functions can still be used but are deprecated and may be removed in a
+future release.  Do not use them anymore in new code!  Also see the description of the
+individual functions on how using code should be updated.
+
+.. autofunction:: cluster_utils.read_params_from_cmdline
+
+.. autofunction:: cluster_utils.save_metrics_params

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -25,7 +25,6 @@ Client / Job Script
 
 The jobs are executed by the cluster system on the compute nodes of the cluster.  They
 execute the user script that is specified with the :confval:`script_relative_path`
-setting.  This script is expected to call :func:`cluster_utils.read_params_from_cmdline`
-in the beginning, to register at the server (so the server knows that the job started),
-and :func:`cluster_utils.save_metrics_params` at the end to send its results to the
-server.
+setting.  This script is expected to call :func:`cluster_utils.initialize_job` in the
+beginning, to register at the server (so the server knows that the job started), and
+:func:`cluster_utils.finalize_job` at the end to send its results to the server.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ import sphinx.domains.python
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "myst_parser",
@@ -137,6 +138,9 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
 html_static_path: typing.List[str] = []
+
+
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 
 object_description_options = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,9 +173,7 @@ def setup(app):
 
         if value_type is not None:
             node += sphinx.addnodes.desc_sig_punctuation(" : ", " : ")
-
-            annotations = sphinx.domains.python._parse_annotation(value_type, env)
-            node += sphinx.addnodes.desc_type("", "", *annotations)
+            node += sphinx.addnodes.desc_type("", value_type)
 
         if default_value is not None:
             node += sphinx.addnodes.desc_sig_punctuation(" = ", " = ")

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,20 +119,20 @@ These parameters are the same for ``grid_search`` and ``hp_optimization``.
     Note: while the ``environment_setup`` argument itself is mandatory, all its
     content are optional (i.e. it can be empty).
 
-    .. confval:: environment_setup.pre_job_script: str:
+    .. confval:: environment_setup.pre_job_script: str
 
         Path to an executable (e.g. bash script) that is executed before the main script
         runs.
 
-    .. confval:: environment_setup.virtual_env_path: str:
+    .. confval:: environment_setup.virtual_env_path: str
 
         Path of folder of virtual environment to activate.
 
-    .. confval:: environment_setup.conda_env_path: str:
+    .. confval:: environment_setup.conda_env_path: str
 
         Name of conda environment to activate (this option might be broken).
 
-    .. confval:: environment_setup.variables: dict[str]:
+    .. confval:: environment_setup.variables: dict[str]
 
         Environment variables to set. Variables are set *after* a virtual/conda environment 
         is activated, thus override environment variables set before. They are also set 
@@ -140,11 +140,11 @@ These parameters are the same for ``grid_search`` and ``hp_optimization``.
         parameters to the script, e.g. to setup a generic script that changes its behavior based 
         on the values defined in the cluster_utils config file.
 
-    .. confval:: environment_setup.is_python_script: bool, default=true:
+    .. confval:: environment_setup.is_python_script: bool = true
 
         Whether the target to run is a Python script.
 
-    .. confval:: environment_setup.run_as_module: bool, default=false:
+    .. confval:: environment_setup.run_as_module: bool = false
 
         Whether to run the script as a Python module
         (``python -m my_package.my_module``) or as a script

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -497,7 +497,7 @@ settings (i.e. the ones independent of the optimisation method set in
     **Required.**
 
     Name of the metric that is used for the optimisation.  Has to match the name of one
-    of the metrics that are saved with :func:`~cluster_utils.client.finalize_job`.
+    of the metrics that are saved with :func:`~cluster_utils.finalize_job`.
 
 .. confval:: optimization_setting.minimize: bool
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -8,8 +8,8 @@ Below is a list of error messages that may occur with potential solutions.
 
 **Pandas DataError: No numeric types to aggregate**
 
-If one of the values stored with :func:`~cluster_utils.client.finalize_job` has a
-non-numeric type (e.g. string).
+If one of the values stored with :func:`~cluster_utils.finalize_job` has a non-numeric
+type (e.g. string).
 
 
 ------


### PR DESCRIPTION
- Fix several reference warnings during the docs build.  They where actually not critical but due to the amount of them, actually relevant warnings could easily be missed.
- Fix some syntax issues in the list of configuration values.
- Add `initialize_job` and `finalize_job` to the API docs (seems they got accidentally removed when reverting a commit in a previous PR).
- There were still some references to `read_params_from_cmdline`/`save_metrics_params`.  Change them to use the new names.