### PR TITLE
Add dedicated "Usage" page to documentation and revise start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *cluster_utils* is a Python package that simplifies interacting with compute clusters. 
 It is geared towards tasks typical for *machine learning research*, for example running multiple seeds, grid searches, and hyperparameter optimization.
-The package was developed in the [Autonomous Learning group](https://al.is.mpg.de/) at the University of Tübingen.
+The package was developed in the [Autonomous Learning group](https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/lehrstuehle/distributed-intelligence) at the University of Tübingen.
 
 **A note on support.**
 *cluster_utils* was initially developed for inhouse use.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,15 +54,13 @@ For more information see :doc:`usage` and the examples in the ``examples/basic/`
 ``examples/rosenbrock/`` for simple demonstrations.
 
 
-Documentation Content
-=====================
 
-.. If something is changed here, please also update docs/README.md
+.. TABLE OF CONTENTS (all hidden, so they only appear in the navigation bar)
 
 .. toctree::
-   :caption: How-to Guides
    :caption: Basics
    :maxdepth: 1
+   :hidden:
 
    installation
    usage
@@ -71,6 +69,7 @@ Documentation Content
 .. toctree::
    :caption: How-to Guides
    :maxdepth: 1
+   :hidden:
 
    report
    troubleshooting
@@ -82,6 +81,7 @@ Documentation Content
 .. toctree::
    :maxdepth: 1
    :caption: Topic Guides
+   :hidden:
 
    usage_mindset_and_rule_of_thumb
    architecture
@@ -90,6 +90,7 @@ Documentation Content
 .. toctree::
    :maxdepth: 1
    :caption: References
+   :hidden:
 
    configuration
    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,13 +3,15 @@ Cluster Utils Documentation
 ***************************
 
 
-`cluster_utils`_ is a tool for easily running hyperparameter optimization or
-grid search on a HTCondor or Slurm cluster.  It takes care of submitting and
-monitoring the jobs as well as aggregating the results.
+`cluster_utils`_ is a tool for easily running hyperparameter optimization or grid search
+on a Slurm or HTCondor [1]_ cluster.  It takes care of submitting and monitoring the
+jobs as well as aggregating the results.
 
-Note that the implementation for HTCondor is tailored specifically for the
-cluster of the Max Planck Institute of Intelligent Systems.  The Slurm
-implementation is more generic but not as feature-complete yet.
+It is geared towards tasks typical for *machine learning research*, for example running
+multiple seeds, grid searches, and hyperparameter optimization.
+
+cluster_utils is developed by the `Autonomous Learning group`_ at the University of
+Tübingen.
 
 
 Main Features
@@ -17,17 +19,18 @@ Main Features
 
 A non-exhaustive list of features is the following:
 
-- **Automatic Condor/Slurm usage** Jobs are submitted, monitored (with error
-  reporting), and cleaned up in an automated and highly customizable way.
-- **Integrated with git**. Jobs are run from a ``git clone`` with customizable
-  branch and commit number.
-- **PDF & CSV reporting** Both grid search and optimization produce a pdf report
-  with the specification, basic summaries, and plots.
-- **Advanced setting handling** Cluster utils offer a customized settings system
-  based on JSON. Pointers within the JSON file and to other JSON files are
-  supported.
-- **A LOT OF ADDITIONAL SWEETNESS** Most are demonstrated in the examples. Also,
-  read the code ;).
+- **Parametrized jobs and hyperparameter optimization**: run grid searches or
+  multi-stage hyperparameter optimization.
+- **Supports several cluster backends**: currently, Slurm_ and HTCondor_ [1]_, as well
+  as local (single machine runs) are supported. 
+- **Automatic job management**: jobs are submitted, monitored (with error reporting),
+  and cleaned up in an automated way.
+- **Timeouts & restarting of failed jobs**: jobs can be stopped and resubmitted after
+  some time; failed jobs can be (manually) restarted.
+- **Integrated with git**: jobs are run from a `git clone` with customizable branch and
+  commit number to enhance reproducility.
+- **Reporting**: results are summarized in CSV files, and optionally PDF reports with
+  basic summaries and plots.
 
 
 Basic Usage
@@ -84,4 +87,11 @@ Documentation Content
    changelog
 
 
+.. [1] Note that the implementation for HTCondor is tailored specifically for the
+   cluster of the Max Planck Institute of Intelligent Systems and may not work as-is on
+   other HTCondor clusters.
+
 .. _cluster_utils: https://github.com/martius-lab/cluster_utils
+.. _Autonomous Learning group: https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/lehrstuehle/distributed-intelligence
+.. _Slurm: https://slurm.schedmd.com/
+.. _HTCondor: https://htcondor.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,15 +42,16 @@ There are two basic functionalities:
 
    python3 -m cluster_utils.grid_search specification_of_grid_search.json
 
-and
+for grid search and
 
 .. code-block:: bash
 
    python3 -m cluster_utils.hp_optimization specification_of_hp_opt.json
 
-for hyperparameter optimization
+for hyperparameter optimization.
 
-See ``examples/basic`` and ``examples/rosenbrock`` for simple demonstrations.
+For more information see :doc:`usage` and the examples in the ``examples/basic/`` and
+``examples/rosenbrock/`` for simple demonstrations.
 
 
 Documentation Content
@@ -60,9 +61,17 @@ Documentation Content
 
 .. toctree::
    :caption: How-to Guides
+   :caption: Basics
    :maxdepth: 1
 
    installation
+   usage
+
+
+.. toctree::
+   :caption: How-to Guides
+   :maxdepth: 1
+
    report
    troubleshooting
    setup_devel_env

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,98 @@
+*****
+Usage
+*****
+
+Run Hyperparameter Search
+=========================
+
+cluster_utils provides two main commands to run hyperparameter search in different
+modes:
+
+- ``grid_search``:  Simple grid search over specified hyperparameter ranges.
+- ``hp_optimization``:  Uses sampling-based optimization to search for best combination
+  of hyperparameters within the specified ranges.
+
+They are both run as modules via ``python -m`` and expect a configuration file as
+argument:
+
+.. code-block:: bash
+
+   python3 -m cluster_utils.grid_search config_for_grid_search.json
+
+   python3 -m cluster_utils.hp_optimization config_for_hp_optim.json
+
+See :doc:`configuration` for information on the expected structure of the config file
+(note that there are differences between the two methods!).
+
+Optionally, a list of key-value arguments can be provided in addition, to overwrite
+single settings from the config file.  Use dot-notation to specify nested keys.  Example:
+
+.. code-block:: bash
+
+   python3 -m cluster_utils.hp_optimization config.json \
+     'results_dir="/tmp"' 'optimization_setting.run_local=True'
+
+Both commands can also be run with ``--help`` to get a complete list of arguments.
+
+You can abort the hyperparameter search with Ctrl + C at any time.
+
+
+Interactive Mode
+================
+
+While cluster_utils is running, it is possible to enter a command prompt which allows to
+get some information about finished and running jobs, as well as to stop running jobs.
+
+To enter the command prompt, press ESC.  You should now see the following prompt:
+
+::
+
+   Enter command, e.g.  list_jobs, list_running_jobs, list_successful_jobs,
+   list_idle_jobs, show_job, stop_remaining_jobs
+   >>>
+
+You now may enter one of the listed commands or simply press Enter to leave the prompt
+without executing a command.
+
+.. important::
+
+   While the prompt is open, the main loop is blocked, i.e. no new jobs will be
+   submitted during that time.
+
+
+Commands
+--------
+
+.. I'm a bit misusing the confval directive here, but I think as long as there is no
+   name collision with an actual config value, this should be fine and much easier than
+   adding a dedicated directive.
+
+.. confval:: list_jobs
+
+   List IDs of all jobs that have been submitted so far (including finished ones).
+
+.. confval:: list_running_jobs
+
+   List IDs of all jobs that are currently running.
+
+.. confval:: list_successful_jobs
+
+   List IDs of all jobs that finished successfully.
+
+.. confval:: list_idle_jobs
+
+   List IDs of all jobs that have been submitted but not yet started.
+
+.. confval:: show_job
+
+   Will ask for a job ID and show information about this job.
+
+.. confval:: stop_remaining_jobs
+
+   Abort all currently running jobs as well as jobs that already have been submitted but
+   didn't start yet.
+
+   This will not stop submission of new jobs.  If you want to stop cluster_utils
+   completely, press Ctrl + C instead.
+
+

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,13 +2,12 @@
 Usage
 *****
 
-Run Hyperparameter Search
-=========================
+Run Batch of Jobs
+=================
 
-cluster_utils provides two main commands to run hyperparameter search in different
-modes:
+cluster_utils provides two main commands to run batches of jobs on the cluster:
 
-- ``grid_search``:  Simple grid search over specified hyperparameter ranges.
+- ``grid_search``:  Simple grid search over specified parameter ranges.
 - ``hp_optimization``:  Uses sampling-based optimization to search for best combination
   of hyperparameters within the specified ranges.
 
@@ -34,7 +33,8 @@ single settings from the config file.  Use dot-notation to specify nested keys. 
 
 Both commands can also be run with ``--help`` to get a complete list of arguments.
 
-You can abort the hyperparameter search with Ctrl + C at any time.
+You can abort cluster_utils with Ctrl + C at any time. All running jobs are stopped, and
+submitted jobs are removed from the cluster queue.
 
 
 Interactive Mode


### PR DESCRIPTION
- Add a "Usage" page with a bit more information on how to actually run it.  I also added the interactive commands, I hope I got all the descriptions right.
- Revise the start page.  It was based on the old README but didn't get updated accordingly when the README was revised recently.

![2024-06-25 15 16 57  54d556f0be78](https://github.com/martius-lab/cluster_utils/assets/9333121/3a3daa76-709f-43be-9f44-4a66afbceb32)
