### PR TITLE
Update dependency versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ LOCATIONS = (
 def lint(session):
     session.install(".[lint]")
     session.run("black", "--check", *LOCATIONS)
-    session.run("ruff", ".")
+    session.run("ruff", "check", ".")
 
 
 @nox.session(python=PYTHON_VERSIONS, tags=["lint"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ docs = [
 ]
 lint = [
     "black==24.3.0",
-    "ruff==0.1.15",
+    "ruff==0.5.0",
 ]
 mypy = [
     "mypy==1.10.1",
@@ -108,7 +108,7 @@ target-version = "py38"
 # for a complete list of available rules see https://docs.astral.sh/ruff/rules/
 # TODO commented-out rules below should be enabled but currently result in quite
 # a lot of warnings, which need to be fixed first.
-select = [
+lint.select = [
     "F", # pyflakes
     "E", # pycodestyle
     "W", # pycodestyle
@@ -127,12 +127,15 @@ select = [
     # "NPY", # numpy
     "RUF100",  # unused 'noqa' directive
 ]
-ignore = [
+lint.ignore = [
     "E501",  # line too long (mostly handled by black)
     # E731: Do not use a lambda expression use a def (local def is often ugly)
     "E731",
     "PT011",  # pytest-raises-too-broad (use `match` parameter)
     "SIM108",  # Use ternary operator instead of if-else-block
+    # SIM910: use dict.get("foo") instead of dict.get("foo", None)
+    # Disabled as it's sometimes nice to be explicit.
+    "SIM910",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ docs = [
     "sphinx-immaterial",
 ]
 lint = [
-    "black==24.3.0",
+    "black==24.4.2",
     "ruff==0.5.0",
 ]
 mypy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ lint = [
     "ruff==0.1.15",
 ]
 mypy = [
-    "mypy",
+    "mypy==1.10.1",
     "pandas-stubs",
     "tomli-w",
     "types-colorama",
@@ -81,7 +81,7 @@ mypy = [
     "types-PyYaml",
 ]
 test = [
-    "pytest",
+    "pytest==8.2.2",
     "tomli-w",
 ]
 nevergrad = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "colorama",
     "gitpython>=3.0.5",
     "numpy<2",
-    "pandas[output_formatting]==2.0.3",
+    "pandas[output_formatting]>=2.0.3",
     "pyuv @ git+https://github.com/saghul/pyuv.git@2a3d42d44c6315ebd73899a35118380d2d5979b5",
     "scipy",
     "smart_settings @ git+https://github.com/martius-lab/smart-settings.git@eb7331fdcad58d314a842087bbf136735e890013",


### PR DESCRIPTION
## Summary

Based on discussion in #111:
- Relax pandas requirement from `==` to `>=`
- Pin exact versions of all lint tool.  types-* packages for mypy are not pinned, as they are coupled to their actual
library packages (which are not pinned as well).

While already touching this also bump the versions of black and ruff to the latest releases.  For ruff some minor config adjustments and ignoring one rule was necessary.

Closes #111

## How I tested
Via nox.  There are no changes to actual package code, so nothing to test on the cluster.