### PR TITLE
Make server-dependencies optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal modules have been moved to sub-packages.  This should not affect normal users
   which just run cluster_utils via the provided scripts but in cause you have some
   custom scripts, running cluster_utils, you may need to update them.
+- Base dependencies cover only needs of `client` and `base` sub-packages.  For the
+  `server` sub-package (needed to run the cluster_utils applications), install the
+  optional-dependencies group "server".
 
 ### Removed
 - Removed option `save_params` from `read_params_from_cmdline`.  They will always be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   custom scripts, running cluster_utils, you may need to update them.
 - Base dependencies cover only needs of `client` and `base` sub-packages.  For the
   `server` sub-package (needed to run the cluster_utils applications), install the
-  optional-dependencies group "server".
+  optional-dependencies group "runner".
 
 ### Removed
 - Removed option `save_params` from `read_params_from_cmdline`.  They will always be

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,7 @@ The constants listed below define names of output files that are written by
 cluster_utils.  They are listed here, so that other parts of the documentation can
 reference them.
 
-.. automodule:: cluster_utils.constants
+.. automodule:: cluster_utils.base.constants
    :members:
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,11 +16,11 @@ Basic Installation
 for the job scripts.  This is to avoid unnecessary dependencies in your user code
 (assuming you are using a separate virtual environment for it).
 **To be able to run the cluster_utils applications, you need to install it with the
-optional "server" dependencies:**
+optional "runner" dependencies:**
 
 .. code-block:: bash
 
-   pip install "cluster_utils[server] @ git+https://github.com/martius-lab/cluster_utils.git"
+   pip install "cluster_utils[runner] @ git+https://github.com/martius-lab/cluster_utils.git"
 
 
 .. _optional_dependencies:
@@ -30,11 +30,11 @@ Optional Dependencies
 
 Some features require additional dependencies that are not installed by default.  They
 can be installed by specifying the corresponding "optional dependencies group".  Keep in
-mind that you should always also include the "server" group:
+mind that you should always also include the "runner" group:
 
 .. code-block:: bash
 
-   pip install "cluster_utils[server,EXTRA] @ git+https://github.com/martius-lab/cluster_utils.git"
+   pip install "cluster_utils[runner,EXTRA] @ git+https://github.com/martius-lab/cluster_utils.git"
 
 where ``EXTRA`` should be replaced by one of the following identifiers (or multiple,
 separated by commas):
@@ -45,7 +45,7 @@ separated by commas):
 
    * - Identifier
      - Needed for
-   * - **server**
+   * - **runner**
      - Basic dependencies for running cluster_utils applications (see
        :ref:`basic_installation`).
    * - **report**
@@ -53,7 +53,7 @@ separated by commas):
    * - **nevergrad**
      - To use the *nevergrad* optimizer in ``hp_optimization``.
    * - **all**
-     - Alias for 'server,report,nevergrad'.
+     - Alias for 'runner,report,nevergrad'.
    * - **docs**
      - For building the documentation.
    * - **dev**

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,13 +7,20 @@ Requirements
 
 cluster_utils requires Python version >= 3.8.
 
+.. _basic_installation:
 
 Basic Installation
 ==================
 
+**Important:** cluster_utils by default only installs the dependencies that are needed
+for the job scripts.  This is to avoid unnecessary dependencies in your user code
+(assuming you are using a separate virtual environment for it).
+**To be able to run the cluster_utils applications, you need to install it with the
+optional "server" dependencies:**
+
 .. code-block:: bash
 
-   pip install git+https://github.com/martius-lab/cluster_utils.git
+   pip install "cluster_utils[server] @ git+https://github.com/martius-lab/cluster_utils.git"
 
 
 .. _optional_dependencies:
@@ -22,12 +29,12 @@ Optional Dependencies
 =====================
 
 Some features require additional dependencies that are not installed by default.  They
-can be installed by specifying the corresponding "optional dependencies group" like
-this:
+can be installed by specifying the corresponding "optional dependencies group".  Keep in
+mind that you should always also include the "server" group:
 
 .. code-block:: bash
 
-   pip install "cluster[EXTRA] @ git+https://github.com/martius-lab/cluster_utils.git"
+   pip install "cluster_utils[server,EXTRA] @ git+https://github.com/martius-lab/cluster_utils.git"
 
 where ``EXTRA`` should be replaced by one of the following identifiers (or multiple,
 separated by commas):
@@ -38,10 +45,15 @@ separated by commas):
 
    * - Identifier
      - Needed for
+   * - **server**
+     - Basic dependencies for running cluster_utils applications (see
+       :ref:`basic_installation`).
    * - **report**
      - For generating PDF reports (see :doc:`report`).
    * - **nevergrad**
      - To use the *nevergrad* optimizer in ``hp_optimization``.
+   * - **all**
+     - Alias for 'server,report,nevergrad'.
    * - **docs**
      - For building the documentation.
    * - **dev**

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def pytest(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests(session):
-    session.install(".[server]")
+    session.install(".[runner]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run("bash", "tests/run_integration_tests.sh", test_dir, external=True)
@@ -45,7 +45,7 @@ def integration_tests(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests_with_report_generation(session):
-    session.install(".[server,report]")
+    session.install(".[runner,report]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run(
@@ -58,7 +58,7 @@ def integration_tests_with_report_generation(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests_with_nevergrad(session):
-    session.install(".[server,nevergrad]")
+    session.install(".[runner,nevergrad]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run(
@@ -71,7 +71,7 @@ def integration_tests_with_nevergrad(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests_with_venv(session):
-    session.install(".[server]")
+    session.install(".[runner]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,3 +68,16 @@ def integration_tests_with_nevergrad(session):
             test_dir,
             external=True,
         )
+
+
+@nox.session(python=PYTHON_VERSIONS, tags=["test"])
+def integration_tests_with_venv(session):
+    session.install(".")
+
+    with tempfile.TemporaryDirectory() as test_dir:
+        session.run(
+            "bash",
+            "tests/run_integration_tests_with_venv.sh",
+            test_dir,
+            external=True,
+        )

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,14 +24,13 @@ def mypy(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def pytest(session):
-    session.install(".[all]")
-    session.install(".[test]")
+    session.install(".[all,test]")
     session.run("pytest")
 
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests(session):
-    session.install(".")
+    session.install(".[server]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run("bash", "tests/run_integration_tests.sh", test_dir, external=True)
@@ -46,7 +45,7 @@ def integration_tests(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests_with_report_generation(session):
-    session.install(".[report]")
+    session.install(".[server,report]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run(
@@ -59,7 +58,7 @@ def integration_tests_with_report_generation(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests_with_nevergrad(session):
-    session.install(".[nevergrad]")
+    session.install(".[server,nevergrad]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run(
@@ -72,7 +71,7 @@ def integration_tests_with_nevergrad(session):
 
 @nox.session(python=PYTHON_VERSIONS, tags=["test"])
 def integration_tests_with_venv(session):
-    session.install(".")
+    session.install(".[server]")
 
     with tempfile.TemporaryDirectory() as test_dir:
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,9 @@ maintainers = [
     { email = "georg.martius@uni-tuebingen.de" },
 ]
 dependencies = [
-    "colorama",
-    "gitpython>=3.0.5",
-    "numpy<2",
-    "pandas[output_formatting]>=2.0.3",
-    "scipy",
+    # NOTE: List only dependencies of the 'client' and 'base' sub-packages here.
+    # Dependencies of the 'server' sub-package should go to the optional-dependencies.
     "al-smart-settings",
-    "tqdm",
 ]
 
 [tool.setuptools_scm]
@@ -42,7 +38,19 @@ Repository = "https://github.com/martius-lab/cluster_utils"
 Issues = "https://github.com/martius-lab/cluster_utils/issues"
 
 [project.optional-dependencies]
+# all the dependencies that are needed for running the server process of cluster_utils
+# (grid_search/hp_optimization) but are not needed by the job scripts.
+server = [
+    "colorama",
+    "gitpython>=3.0.5",
+    "numpy<2",
+    "pandas[output_formatting]>=2.0.3",
+    "scipy",
+    "tqdm",
+]
+
 all = [
+    "cluster_utils[server]",
     "cluster_utils[nevergrad]",
     "cluster_utils[report]",
 ]
@@ -69,6 +77,7 @@ lint = [
     "ruff==0.5.0",
 ]
 mypy = [
+    "cluster_utils[all]",
     "mypy==1.10.1",
     "pandas-stubs",
     "tomli-w",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Issues = "https://github.com/martius-lab/cluster_utils/issues"
 [project.optional-dependencies]
 # all the dependencies that are needed for running the server process of cluster_utils
 # (grid_search/hp_optimization) but are not needed by the job scripts.
-server = [
+runner = [
     "colorama",
     "gitpython>=3.0.5",
     "numpy<2",
@@ -50,7 +50,7 @@ server = [
 ]
 
 all = [
-    "cluster_utils[server]",
+    "cluster_utils[runner]",
     "cluster_utils[nevergrad]",
     "cluster_utils[report]",
 ]

--- a/src/cluster_utils/base/utils.py
+++ b/src/cluster_utils/base/utils.py
@@ -1,4 +1,61 @@
+import contextlib
+import textwrap
+
 from cluster_utils.base import constants
+
+
+class OptionalDependencyNotFoundError(ModuleNotFoundError):
+    """Error to throw if an optional dependency is not found.
+
+    The error message provided by this class is more informative than a generic
+    ModuleNotFoundError and also includes the proper pip command to install the missing
+    optional dependency.
+    """
+
+    def __init__(self, module: str, optional_dependency_group: str) -> None:
+        """
+        Args:
+            module: Name of the module which was not found.
+            optional_dependency_group: Name of the optional dependency group which
+                should be installed to have the missing package.
+        """
+        super().__init__(name=module)
+
+        self.message = textwrap.dedent(
+            """
+            Failed to import '{module}'.  Make sure you installed the optional '{group}' dependencies.
+            You can do this with:
+            ```
+            # when installing directly from git:
+            pip install "cluster[{group}] @ git+https://github.com/martius-lab/cluster_utils.git"
+
+            # when installing from local working copy:
+            pip install ".[{group}]"
+            ```
+        """.format(
+                module=module, group=optional_dependency_group
+            )
+        )
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class OptionalDependencyImport(contextlib.AbstractContextManager):
+    """Context manager to re-raises ModuleNotFoundError with a more informative message.
+
+    This is to be used for importing packages that are optional dependencies.  It
+    catches an eventual import error and re-raises it as OptionalDependencyNotFoundError.
+    """
+
+    def __init__(self, dependency_group: str) -> None:
+        self.dependency_group = dependency_group
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        if exc_type is ModuleNotFoundError:
+            raise OptionalDependencyNotFoundError(
+                exc_value.name, self.dependency_group
+            ).with_traceback(traceback)
 
 
 def flatten_nested_string_dict(nested_dict, prepend=""):

--- a/src/cluster_utils/client/__init__.py
+++ b/src/cluster_utils/client/__init__.py
@@ -277,9 +277,9 @@ def finalize_job(metrics: MutableMapping[str, float], params) -> None:
     """Save metrics and parameters and send metrics to the cluster_utils server.
 
     Save the used parameters and resulting metrics to CSV files (filenames defined by
-    :attr:`~cluster_utils.constants.CLUSTER_PARAM_FILE` and
-    :attr:`~cluster_utils.constants.CLUSTER_METRIC_FILE`) in the job's working directory
-    and report the metrics to the cluster_utils main process.
+    :attr:`~cluster_utils.base.constants.CLUSTER_PARAM_FILE` and
+    :attr:`~cluster_utils.base.constants.CLUSTER_METRIC_FILE`) in the job's working
+    directory and report the metrics to the cluster_utils main process.
 
     Make sure to call this function at the end of your job script, otherwise
     cluster_utils will not receive the resulting metrics and will consider the job as

--- a/src/cluster_utils/grid_search.py
+++ b/src/cluster_utils/grid_search.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from cluster_utils.base.utils import OptionalDependencyImport
 
-with OptionalDependencyImport("server"):
+with OptionalDependencyImport("runner"):
     from cluster_utils.base.constants import FULL_DF_FILE
     from cluster_utils.server.git_utils import make_git_params
     from cluster_utils.server.job_manager import grid_search

--- a/src/cluster_utils/grid_search.py
+++ b/src/cluster_utils/grid_search.py
@@ -6,21 +6,27 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-from cluster_utils.base.constants import FULL_DF_FILE
-from cluster_utils.server.git_utils import make_git_params
-from cluster_utils.server.job_manager import grid_search
-from cluster_utils.server.latex_utils import SectionFromJsonHook, StaticSectionGenerator
-from cluster_utils.server.settings import (
-    GenerateReportSetting,
-    SingularitySettings,
-    init_main_script_argument_parser,
-    read_main_script_params_from_args,
-)
-from cluster_utils.server.utils import (
-    get_time_string,
-    make_temporary_dir,
-    save_report_data,
-)
+from cluster_utils.base.utils import OptionalDependencyImport
+
+with OptionalDependencyImport("server"):
+    from cluster_utils.base.constants import FULL_DF_FILE
+    from cluster_utils.server.git_utils import make_git_params
+    from cluster_utils.server.job_manager import grid_search
+    from cluster_utils.server.latex_utils import (
+        SectionFromJsonHook,
+        StaticSectionGenerator,
+    )
+    from cluster_utils.server.settings import (
+        GenerateReportSetting,
+        SingularitySettings,
+        init_main_script_argument_parser,
+        read_main_script_params_from_args,
+    )
+    from cluster_utils.server.utils import (
+        get_time_string,
+        make_temporary_dir,
+        save_report_data,
+    )
 
 
 def main() -> int:

--- a/src/cluster_utils/hp_optimization.py
+++ b/src/cluster_utils/hp_optimization.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from cluster_utils.base.utils import OptionalDependencyImport
 
-with OptionalDependencyImport("server"):
+with OptionalDependencyImport("runner"):
     from cluster_utils.server import distributions, latex_utils
     from cluster_utils.server.git_utils import make_git_params
     from cluster_utils.server.job_manager import hp_optimization

--- a/src/cluster_utils/hp_optimization.py
+++ b/src/cluster_utils/hp_optimization.py
@@ -10,19 +10,22 @@ import os
 import sys
 from pathlib import Path
 
-from cluster_utils.server import distributions, latex_utils
-from cluster_utils.server.git_utils import make_git_params
-from cluster_utils.server.job_manager import hp_optimization
-from cluster_utils.server.settings import (
-    GenerateReportSetting,
-    SingularitySettings,
-    init_main_script_argument_parser,
-    read_main_script_params_from_args,
-)
-from cluster_utils.server.utils import (
-    get_time_string,
-    make_temporary_dir,
-)
+from cluster_utils.base.utils import OptionalDependencyImport
+
+with OptionalDependencyImport("server"):
+    from cluster_utils.server import distributions, latex_utils
+    from cluster_utils.server.git_utils import make_git_params
+    from cluster_utils.server.job_manager import hp_optimization
+    from cluster_utils.server.settings import (
+        GenerateReportSetting,
+        SingularitySettings,
+        init_main_script_argument_parser,
+        read_main_script_params_from_args,
+    )
+    from cluster_utils.server.utils import (
+        get_time_string,
+        make_temporary_dir,
+    )
 
 
 def get_distribution(distribution, **kwargs):

--- a/src/cluster_utils/scripts/plot_job_timeline.py
+++ b/src/cluster_utils/scripts/plot_job_timeline.py
@@ -183,7 +183,7 @@ def plot_timeline(
         color = colors[job_id % len(colors)]
         for interval in intervals:
             ax.plot(
-                [interval.start_time, interval.end_time],
+                [interval.start_time, interval.end_time],  # type: ignore
                 [job_id, job_id],
                 "-",
                 lw=3,

--- a/src/cluster_utils/server/__init__.py
+++ b/src/cluster_utils/server/__init__.py
@@ -1,4 +1,5 @@
 """Server modules and scripts of cluster_utils.
 
-The `server` sub-package contains everything that is only needed for running the server scripts (e.g. `grid_search`/`hp_optimization`) but is not needed for the job scripts.
+The `server` sub-package contains everything that is only needed for running the server
+scripts (e.g. `grid_search`/`hp_optimization`) but is not needed for the job scripts.
 """

--- a/src/cluster_utils/server/optimizers.py
+++ b/src/cluster_utils/server/optimizers.py
@@ -10,9 +10,10 @@ from typing import TYPE_CHECKING, Sequence
 import pandas as pd
 
 from cluster_utils.base import constants
+from cluster_utils.base.utils import OptionalDependencyImport
 
 from . import data_analysis, distributions
-from .utils import OptionalDependencyImport, get_sample_generator, nested_to_dict
+from .utils import get_sample_generator, nested_to_dict
 
 if TYPE_CHECKING:
     from . import latex_utils

--- a/src/cluster_utils/server/report.py
+++ b/src/cluster_utils/server/report.py
@@ -7,7 +7,7 @@ from itertools import combinations, count
 from tempfile import TemporaryDirectory
 from typing import Any, Iterator, Mapping, Optional, Sequence
 
-from .utils import OptionalDependencyImport
+from cluster_utils.base.utils import OptionalDependencyImport
 
 with OptionalDependencyImport("report"):
     import matplotlib.pyplot as plt

--- a/src/cluster_utils/server/utils.py
+++ b/src/cluster_utils/server/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import collections
-import contextlib
 import datetime
 import enum
 import itertools
@@ -13,7 +12,6 @@ import pickle
 import random
 import re
 import shutil
-import textwrap
 from collections import defaultdict
 from pathlib import Path
 from time import sleep
@@ -22,60 +20,6 @@ from typing import Any
 import colorama
 
 from cluster_utils.base import constants
-
-
-class OptionalDependencyNotFoundError(ModuleNotFoundError):
-    """Error to throw if an optional dependency is not found.
-
-    The error message provided by this class is more informative than a generic
-    ModuleNotFoundError and also includes the proper pip command to install the missing
-    optional dependency.
-    """
-
-    def __init__(self, module: str, optional_dependency_group: str) -> None:
-        """
-        Args:
-            module: Name of the module which was not found.
-            optional_dependency_group: Name of the optional dependency group which
-                should be installed to have the missing package.
-        """
-        super().__init__(name=module)
-
-        self.message = textwrap.dedent(
-            """
-            Failed to import '{module}'.  Make sure you installed the optional '{group}' dependencies.
-            You can do this with:
-            ```
-            # when installing directly from git:
-            pip install "cluster[{group}] @ git+https://github.com/martius-lab/cluster_utils.git"
-
-            # when installing from local working copy:
-            pip install ".[{group}]"
-            ```
-        """.format(
-                module=module, group=optional_dependency_group
-            )
-        )
-
-    def __str__(self) -> str:
-        return self.message
-
-
-class OptionalDependencyImport(contextlib.AbstractContextManager):
-    """Context manager to re-raises ModuleNotFoundError with a more informative message.
-
-    This is to be used for importing packages that are optional dependencies.  It
-    catches an eventual import error and re-raises it as OptionalDependencyNotFoundError.
-    """
-
-    def __init__(self, dependency_group: str) -> None:
-        self.dependency_group = dependency_group
-
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        if exc_type is ModuleNotFoundError:
-            raise OptionalDependencyNotFoundError(
-                exc_value.name, self.dependency_group
-            ).with_traceback(traceback)
 
 
 class ClusterRunType(enum.Enum):

--- a/tests/grid_search_with_venv.toml
+++ b/tests/grid_search_with_venv.toml
@@ -1,0 +1,45 @@
+optimization_procedure_name = "test_grid_search"
+run_in_working_dir = true
+generate_report = "never"
+script_relative_path = "examples/basic/main_no_fail.py"
+remove_jobs_dir = true
+restarts = 1
+
+[git_params]
+branch = "master"
+
+[environment_setup]
+# The actual venv will be created in a new temporary directory for each test run, so it
+# is only known at runtime and will be passed as command line argument.
+virtual_env_path = "PLACEHOLDER"
+
+[environment_setup.variables]
+TEST_VARIABLE = "test_value"
+
+[cluster_requirements]
+request_cpus = 1
+request_gpus = 0
+memory_in_mb = 16000
+bid = 800
+
+[fixed_params]
+test_resume = false
+max_sleep_time = 1
+"fn_args.w" = 1
+"fn_args.x" = 3.0
+"fn_args.y" = 0.1
+"fn_args.sharp_penalty" = false
+
+[[hyperparam_list]]
+param = "fn_args.u"
+values = [
+    -0.5,
+    0.5,
+]
+
+[[hyperparam_list]]
+param = "fn_args.v"
+values = [
+    10,
+    50,
+]

--- a/tests/run_integration_tests_with_venv.sh
+++ b/tests/run_integration_tests_with_venv.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+test_dir=$1
+
+# create venv for the jobs in temporary directory
+venv_dir="${test_dir}/venv"
+python -m venv "$venv_dir"
+source "${venv_dir}/bin/activate"
+# upgrade pip to avoid potential installation issues
+pip install -U pip
+# install cluster_utils in the venv
+pip install .
+# install dependencies of the test script itself
+pip install numpy
+deactivate
+
+# The config doesn't contain the actual path to the venv, so we need to pass it
+# here.
+python -m cluster_utils.grid_search "tests/grid_search_with_venv.toml" \
+    "no_user_interaction=True" \
+    "results_dir='$test_dir'" \
+    "environment_setup.virtual_env_path='${venv_dir}'" \
+    <<EOF
+y
+y
+EOF
+# ^This is a temporary crutch because we need to say Yes to the questions cluster_utils asks


### PR DESCRIPTION
Move all the dependencies that are only needed for running the main (aka server) process but not for the job scripts into an optional dependencies group "server". This dramatically reduces dependencies for the user code, making installation faster and reducing potential version conflicts.

So now, user code which only needs the client API can simply depend on "cluster_utils" as before, but for running the cluster_utils applications (`grid_search`/`hp_optimization`), one needs to install "cluster_utils[server]".

Imports of these applications are wrapped with `OptionalDependencyImport("server")`, to give the user a useful error message in case the necessary dependencies have not been installed.  For this, `OptionalDependencyImport` has been moved to `base.utils`, so it can be imported without triggering any server dependency imports.

Also added a new integration test which uses a venv, for verifying that the client API is actually working with the provided dependencies.

Closes #83.

@mseitzer I'm not really happy with the name "server" for the dependency group but couldn't come up with a better one.  It makes sense from a technical point of view, as it contains the dependencies for the "server" sub-package but is maybe not super intuitive for the user.  Please let me know in case you have a good idea.