### PR TITLE
Handle shutdown outside of signal handler & use context manager for progress bars

### DIFF
--- a/src/cluster_utils/server/job_manager.py
+++ b/src/cluster_utils/server/job_manager.py
@@ -361,13 +361,13 @@ def hp_optimization(
     interaction_mode = NonInteractiveMode if no_user_interaction else InteractiveMode
     with interaction_mode(
         cluster_interface, comm_server
-    ) as check_for_keyboard_input, redirect_stdout_to_tqdm():
-        submitted_bar = SubmittedJobsBar(total_jobs=number_of_samples)
-        running_bar = RunningJobsBar(total_jobs=number_of_samples)
-        successful_jobs_bar = CompletedJobsBar(
-            total_jobs=number_of_samples, minimize=minimize
-        )
-
+    ) as check_for_keyboard_input, redirect_stdout_to_tqdm(), SubmittedJobsBar(
+        total_jobs=number_of_samples
+    ) as submitted_bar, RunningJobsBar(
+        total_jobs=number_of_samples
+    ) as running_bar, CompletedJobsBar(
+        total_jobs=number_of_samples, minimize=minimize
+    ) as successful_jobs_bar:
         while cluster_interface.n_completed_jobs < number_of_samples:
             check_for_keyboard_input()
             time.sleep(constants.JOB_MANAGER_LOOP_SLEEP_TIME_IN_SECS)
@@ -483,6 +483,8 @@ def hp_optimization(
                     minimize,
                     **early_killing_params,
                 )
+
+    print()  # empty line after progress bars
 
     post_iteration_opt(
         cluster_interface,
@@ -621,11 +623,13 @@ def grid_search(
     interaction_mode = NonInteractiveMode if no_user_interaction else InteractiveMode
     with interaction_mode(
         cluster_interface, comm_server
-    ) as check_for_keyboard_input, redirect_stdout_to_tqdm():
-        submitted_bar = SubmittedJobsBar(total_jobs=len(jobs))
-        running_bar = RunningJobsBar(total_jobs=len(jobs))
-        successful_jobs_bar = CompletedJobsBar(total_jobs=len(jobs), minimize=None)
-
+    ) as check_for_keyboard_input, redirect_stdout_to_tqdm(), SubmittedJobsBar(
+        total_jobs=len(jobs)
+    ) as submitted_bar, RunningJobsBar(
+        total_jobs=len(jobs)
+    ) as running_bar, CompletedJobsBar(
+        total_jobs=len(jobs), minimize=None
+    ) as successful_jobs_bar:
         num_jobs_to_submit_per_iteration = 5
         while cluster_interface.n_completed_jobs != len(jobs):
             # submit next batch of jobs
@@ -663,6 +667,8 @@ def grid_search(
                 )
             check_for_keyboard_input()
             time.sleep(constants.JOB_MANAGER_LOOP_SLEEP_TIME_IN_SECS)
+
+    print()  # empty line after progress bars
 
     post_opt(cluster_interface)
 

--- a/src/cluster_utils/server/progress_bars.py
+++ b/src/cluster_utils/server/progress_bars.py
@@ -49,6 +49,11 @@ class ProgressBar(ABC):
     def close(self):
         self.tqdm.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
 
 # Color disabled until a bug in tqdm is fixed.
 # see https://stackoverflow.com/questions/58328625/tqdm-colored-progress-bar-printing-on-multiple-lines

--- a/src/cluster_utils/server/progress_bars.py
+++ b/src/cluster_utils/server/progress_bars.py
@@ -55,6 +55,7 @@ class ProgressBar(ABC):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
 
+
 # Color disabled until a bug in tqdm is fixed.
 # see https://stackoverflow.com/questions/58328625/tqdm-colored-progress-bar-printing-on-multiple-lines
 

--- a/src/cluster_utils/server/utils.py
+++ b/src/cluster_utils/server/utils.py
@@ -38,14 +38,24 @@ class SignalWatcher:
     signal was received.
 
     **Note:** This overwrites any existing signal handler for the specified signal.
+
+    Signal flags are stored in a class variable, so they are shared among all instances.
+    This allows use of multiple instances for the same signal in different places of the
+    code.
     """
+
+    # Use a class variable dict to store received signals.  This dict will be shared
+    # among all instances of SignalWatcher and thus allow multiple instances to watch
+    # the same signal without ousting each other (since new instances will overwrite the
+    # signal handler of the older ones).
+    received_signals: dict[signal.Signals, bool] = {}
 
     def __init__(self, signal_to_watch_for: int = signal.SIGINT) -> None:
         """
         Args:
             signal_to_watch_for: The signal to watch for.
         """
-        self.received_signal = False
+        self.signal = signal_to_watch_for
         signal.signal(signal_to_watch_for, self._signal_handler)
 
     def _signal_handler(self, sig, frame) -> None:
@@ -55,7 +65,7 @@ class SignalWatcher:
             sig (int): The signal number.
             frame (frame object): The current stack frame.
         """
-        self.received_signal = True
+        SignalWatcher.received_signals[sig] = True
 
     def has_received_signal(self) -> bool:
         """Checks if the signal has been received.
@@ -63,7 +73,7 @@ class SignalWatcher:
         Returns:
             bool: True if the signal has been received, False otherwise.
         """
-        return self.received_signal
+        return self.signal in SignalWatcher.received_signals
 
 
 def shorten_string(string, max_len):

--- a/src/cluster_utils/server/utils.py
+++ b/src/cluster_utils/server/utils.py
@@ -31,7 +31,14 @@ class ClusterRunType(enum.Enum):
 
 
 class SignalWatcher:
-    """Watch for a signal."""
+    """Watch for a signal.
+
+    Upon initialization, a signal handler is registered to watch for the specified
+    signal.  The method :meth:`has_received_signal` can then be used to check if the
+    signal was received.
+
+    **Note:** This overwrites any existing signal handler for the specified signal.
+    """
 
     def __init__(self, signal_to_watch_for: int = signal.SIGINT) -> None:
         """

--- a/src/cluster_utils/server/utils.py
+++ b/src/cluster_utils/server/utils.py
@@ -29,6 +29,35 @@ class ClusterRunType(enum.Enum):
     HP_OPTIMIZATION = 1
 
 
+class SignalWatcher:
+    """Watch for a signal."""
+
+    def __init__(self, signal_to_watch_for: int = signal.SIGINT) -> None:
+        """
+        Args:
+            signal_to_watch_for: The signal to watch for.
+        """
+        self.received_signal = False
+        signal.signal(signal_to_watch_for, self._signal_handler)
+
+    def _signal_handler(self, sig, frame) -> None:
+        """Handles the received signal.
+
+        Args:
+            sig (int): The signal number.
+            frame (frame object): The current stack frame.
+        """
+        self.received_signal = True
+
+    def has_received_signal(self) -> bool:
+        """Checks if the signal has been received.
+
+        Returns:
+            bool: True if the signal has been received, False otherwise.
+        """
+        return self.received_signal
+
+
 def shorten_string(string, max_len):
     if len(string) > max_len - 3:
         return "..." + string[-max_len + 3 :]

--- a/src/cluster_utils/server/utils.py
+++ b/src/cluster_utils/server/utils.py
@@ -12,6 +12,7 @@ import pickle
 import random
 import re
 import shutil
+import signal
 from collections import defaultdict
 from pathlib import Path
 from time import sleep


### PR DESCRIPTION
Handling the shutdown on SIGINT (including sys.exit()) within the signal handler function is problematic as the signal can be received multiple times before the application actually exists.  This results in the duplicated prints and potentially other issues.
Instead, only set a flag in the signal handler, which is then checked in each iteration of the main loop.  Add a simple `SignalWatcher` utility class for this.
Unfortunately this adds more redundant code in `hp_optimization()` and `grid_search()` but I don't see an easy way to avoid that at the moment.

And another change that is indirectly related as it was necessary to avoid messy output:
Use context manager for the progress bars to make sure they are properly closed when the loop finishes.  This results in much nicer output, as prints by following code will come _after_ the progress bars and not randomly somewhere _within_ them.

Below is the output of `grid_search` when run locally and Ctrl+C gets pressed.

before:
![Screenshot_grid_search_before](https://github.com/user-attachments/assets/e4558d52-418b-4e2c-be02-db11b0b271ad)

after:
![Screenshot_grid_search_after](https://github.com/user-attachments/assets/df4f866e-d838-4e16-ac4a-8ea3b795be62)


# How I Tested
Ran examples locally.  Test on galvani is pending as the login node is not really responsive at the moment...