### PR TITLE
fix: Use correct package name in error message

### DIFF
--- a/src/cluster_utils/base/utils.py
+++ b/src/cluster_utils/base/utils.py
@@ -27,7 +27,7 @@ class OptionalDependencyNotFoundError(ModuleNotFoundError):
             You can do this with:
             ```
             # when installing directly from git:
-            pip install "cluster[{group}] @ git+https://github.com/martius-lab/cluster_utils.git"
+            pip install "cluster_utils[{group}] @ git+https://github.com/martius-lab/cluster_utils.git"
 
             # when installing from local working copy:
             pip install ".[{group}]"


### PR DESCRIPTION
The error message in OptionalDependencyNotFoundError was still using the package name "cluster" in the install command.  Change this to use the new name "cluster_utils".