### PR TITLE
chore: Run linter/tests also for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import tempfile
 
 import nox
 
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 
 @nox.session(python=PYTHON_VERSIONS, tags=["lint"])


### PR DESCRIPTION
We should keep track with new Python versions.

Python 3.8 actually reached EOL, so we could drop support for it.  However, I'd keep it for now and only drop it if there is an actual reason (e.g. a dependency issue or newer language feature that we want to use).