### PR TITLE
Print warning when report generation failed.

### DIFF
--- a/src/cluster_utils/server/report.py
+++ b/src/cluster_utils/server/report.py
@@ -22,7 +22,7 @@ from cluster_utils.base import constants
 from . import data_analysis, distributions
 from .latex_utils import LatexFile
 from .optimizers import Optimizer
-from .utils import log_and_print, shorten_string
+from .utils import log_and_print, make_red, shorten_string
 
 
 def init_plotting():
@@ -313,7 +313,12 @@ def produce_gridsearch_report(
             latex.produce_pdf(output_file)
             log_and_print(logger, f"Report saved at {output_file}")
         except Exception:
-            logging.warning("Could not generate PDF report", exc_info=True)
+            logging.warning("Failed to generate PDF report", exc_info=True)
+            print(
+                make_red(
+                    "Warning: Failed to generate PDF report.  See log for details."
+                )
+            )
 
 
 def distribution_plots(
@@ -494,4 +499,9 @@ def produce_optimization_report(
             latex.produce_pdf(output_file)
             logger.info("Saved report to %s", output_file)
         except Exception:
-            logger.warning("Could not generate PDF report", exc_info=True)
+            logger.warning("Failed to generate PDF report", exc_info=True)
+            print(
+                make_red(
+                    "Warning: Failed to generate PDF report.  See log for details."
+                )
+            )


### PR DESCRIPTION
So far, a failure during report generation was logged but not printed to the terminal, so it could easily be missed by the user.

To change this, also print an explicit, red warning to the terminal in that case.