### PR TITLE
Improve user experience of interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved documentation from GitHub Pages to Read the Docs.  This allows to more easily
   manage docs for different versions.
+- Interactive command `show_job` now expects job ID as argument.
 
 ### Added
 - Support for Numpy 2.
 - Tab-completion and history for interactive mode.
+- `help` command in interactive mode.
 
 
 ## [3.0.0] - 2024-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for Numpy 2.
+- Tab-completion and history for interactive mode.
 
 
 ## [3.0.0] - 2024-08-19

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,14 +50,16 @@ get some information about finished and running jobs, as well as to stop running
 
 To enter the command prompt, press ESC.  You should now see the following prompt:
 
-::
+.. code-block:: text
 
-   Enter command, e.g.  list_jobs, list_running_jobs, list_successful_jobs,
-   list_idle_jobs, show_job, stop_remaining_jobs
-   >>>
+    ============= COMMAND MODE =============
+    Type 'help' or '?' to list commands.
+    Press enter with empty line to exit command mode.
 
-You now may enter one of the listed commands or simply press Enter to leave the prompt
-without executing a command.
+    >>>
+
+You now may enter one of the commands listed below (you can use tab-completion).  To
+leave the command mode, simply press Enter without a command.
 
 .. important::
 
@@ -71,6 +73,11 @@ Commands
 .. I'm a bit misusing the confval directive here, but I think as long as there is no
    name collision with an actual config value, this should be fine and much easier than
    adding a dedicated directive.
+
+.. confval:: help
+
+   Show help.  Without argument, a list of all commands is shown.  Specify a command as
+   argument to see the help for that command.
 
 .. confval:: list_jobs
 
@@ -99,5 +106,3 @@ Commands
 
    This will not stop submission of new jobs.  If you want to stop cluster_utils
    completely, press Ctrl + C instead.
-
-

--- a/src/cluster_utils/server/user_interaction.py
+++ b/src/cluster_utils/server/user_interaction.py
@@ -61,13 +61,20 @@ class InteractiveMode(cmd.Cmd):
         """List IDs of all jobs that have been submitted but not yet started."""
         self.print("List of idle jobs:")
         self.print([job.id for job in self.cluster_interface.idle_jobs])
-
-    def do_show_job(self, _):
-        "Show information about a specific job."
         return True
+
+    def do_show_job(self, arg: str):
+        """Show information about a specific job.
+
+        Usage: show_job <job_id>
+        """
+        if not arg:
+            self.print("No job ID provided.")
+            self.print("Usage: show_job <job_id>")
+            return False
+
         try:
-            self.print("Enter ID")
-            job_id = int(input())
+            job_id = int(arg)
             job = self.cluster_interface.get_job(job_id)
             [self.print(attr, ": ", job.__dict__[attr]) for attr in job.__dict__]
         except Exception:
@@ -75,6 +82,14 @@ class InteractiveMode(cmd.Cmd):
             return False
 
         return True
+
+    def complete_show_job(self, text, line, begidx, endidx):
+        """Tab completion for show_job command."""
+        return [
+            str(job.id)
+            for job in self.cluster_interface.jobs
+            if str(job.id).startswith(text)
+        ]
 
     def do_stop_remaining_jobs(self, _):
         """Abort all submitted jobs.

--- a/src/cluster_utils/server/user_interaction.py
+++ b/src/cluster_utils/server/user_interaction.py
@@ -43,16 +43,19 @@ class InteractiveMode(cmd.Cmd):
         """
         self.print("List of all jobs:")
         self.print([job.id for job in self.cluster_interface.jobs])
+        return True
 
     def do_list_running_jobs(self, _):
         """List IDs of all jobs that are currently running."""
         self.print("List of running jobs:")
         self.print([job.id for job in self.cluster_interface.running_jobs])
+        return True
 
     def do_list_successful_jobs(self, _):
         """List IDs of all jobs that finished successfully."""
         self.print("List of successful jobs:")
         self.print([job.id for job in self.cluster_interface.successful_jobs])
+        return True
 
     def do_list_idle_jobs(self, _):
         """List IDs of all jobs that have been submitted but not yet started."""
@@ -61,6 +64,7 @@ class InteractiveMode(cmd.Cmd):
 
     def do_show_job(self, _):
         "Show information about a specific job."
+        return True
         try:
             self.print("Enter ID")
             job_id = int(input())
@@ -68,6 +72,9 @@ class InteractiveMode(cmd.Cmd):
             [self.print(attr, ": ", job.__dict__[attr]) for attr in job.__dict__]
         except Exception:
             self.print("Error encountered, maybe invalid ID?")
+            return False
+
+        return True
 
     def do_stop_remaining_jobs(self, _):
         """Abort all submitted jobs.
@@ -101,21 +108,23 @@ class InteractiveMode(cmd.Cmd):
         except Exception:
             self.print("Error encountered")
 
-    def emptyline(self):
-        # do not execute a command when pressing enter with empty line
-        pass
-
-    def postcmd(self, stop, line):
-        # exit loop after one command, except for help command
-        if line.startswith("?") or line.startswith("help"):
-            return False
-
-        # print a line to separate command output from progress output
-        print("========================================")
         return True
 
+    def emptyline(self):
+        # Do not execute a command when pressing enter with empty line.
+        # Return True, to exit the command loop.
+        return True
+
+    def postcmd(self, stop, line):
+        # if command returned True (usually the case if there is no error), exit the
+        # command loop
+        if stop:
+            # print a line to separate command output from progress output
+            print("========================================")
+            return True
+
     def keyboard_input_available(self):
-        # checks if theres sth to read from stdin
+        # checks if there is something to read from stdin
         return select.select([sys.stdin], [], [], 0) == ([sys.stdin], [], [])
 
     def check_for_input(self):

--- a/src/cluster_utils/server/user_interaction.py
+++ b/src/cluster_utils/server/user_interaction.py
@@ -42,25 +42,25 @@ class InteractiveMode(cmd.Cmd):
         This includes jobs that have finished already.
         """
         self.print("List of all jobs:")
-        self.print([job.id for job in self.cluster_interface.jobs])
+        self.columnize([str(job.id) for job in self.cluster_interface.jobs])
         return True
 
     def do_list_running_jobs(self, _):
         """List IDs of all jobs that are currently running."""
         self.print("List of running jobs:")
-        self.print([job.id for job in self.cluster_interface.running_jobs])
+        self.columnize([str(job.id) for job in self.cluster_interface.running_jobs])
         return True
 
     def do_list_successful_jobs(self, _):
         """List IDs of all jobs that finished successfully."""
         self.print("List of successful jobs:")
-        self.print([job.id for job in self.cluster_interface.successful_jobs])
+        self.columnize([str(job.id) for job in self.cluster_interface.successful_jobs])
         return True
 
     def do_list_idle_jobs(self, _):
         """List IDs of all jobs that have been submitted but not yet started."""
         self.print("List of idle jobs:")
-        self.print([job.id for job in self.cluster_interface.idle_jobs])
+        self.columnize([str(job.id) for job in self.cluster_interface.idle_jobs])
         return True
 
     def do_show_job(self, arg: str):
@@ -109,7 +109,7 @@ class InteractiveMode(cmd.Cmd):
                 for job in self.cluster_interface.jobs
                 if job not in self.cluster_interface.successful_jobs
             ]
-            self.print(jobs_to_cancel)
+            self.columnize(list(map(str, jobs_to_cancel)))
             answer = input()
             if answer.lower() in ["y", "yes"]:
                 logger = logging.getLogger("cluster_utils")

--- a/src/cluster_utils/server/user_interaction.py
+++ b/src/cluster_utils/server/user_interaction.py
@@ -41,25 +41,21 @@ class InteractiveMode(cmd.Cmd):
 
         This includes jobs that have finished already.
         """
-        self.print("List of all jobs:")
         self.columnize([str(job.id) for job in self.cluster_interface.jobs])
         return True
 
     def do_list_running_jobs(self, _):
         """List IDs of all jobs that are currently running."""
-        self.print("List of running jobs:")
         self.columnize([str(job.id) for job in self.cluster_interface.running_jobs])
         return True
 
     def do_list_successful_jobs(self, _):
         """List IDs of all jobs that finished successfully."""
-        self.print("List of successful jobs:")
         self.columnize([str(job.id) for job in self.cluster_interface.successful_jobs])
         return True
 
     def do_list_idle_jobs(self, _):
         """List IDs of all jobs that have been submitted but not yet started."""
-        self.print("List of idle jobs:")
         self.columnize([str(job.id) for job in self.cluster_interface.idle_jobs])
         return True
 

--- a/src/cluster_utils/server/user_interaction.py
+++ b/src/cluster_utils/server/user_interaction.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+import readline
 import select
 import sys
 import termios
@@ -19,6 +22,20 @@ class InteractiveMode:
             "show_job": self.show_job,
             "stop_remaining_jobs": self.stop_remaining_jobs,
         }
+
+        # set up tab completion
+        def complete(text: str, n: int) -> str | None:
+            """Return the n-th possible completion for text.
+
+            If there are less then n possible completions, return None.
+            """
+            matches = [cmd for cmd in self.input_to_fn_dict if cmd.startswith(text)]
+            if n < len(matches):
+                return matches[n]
+            return None
+
+        readline.parse_and_bind("tab: complete")
+        readline.set_completer(complete)
 
     def __enter__(self):
         self.old_settings = termios.tcgetattr(sys.stdin)


### PR DESCRIPTION
## Description

Use `cmd.Cmd` for interactive mode.  This gives some benefits over doing things manually:

- Tab completion and history of commands
- `help` command for free
- Code gets a bit nicer
- Allows to easily add command arguments.  This is already done for `show_job` which now expects the ID as argument instead of separately prompting for it (as a bonus, there is even tab completion for the argument :) ).

While working on this, also make the output a bit nicer:
- Remove superfluous prints (no need to say this is the "list of successfull jobs" if just one line above I entered the command `list_successful_jobs`).
- Use `Cmd.columnize` for lists of job IDs.  Results in much nicer, more readable output.


Note that calling `show_job` without argument now results in an error (expects ID as argument).  I don't consider this as breaking change w.r.t. versioning, though, as it only affects the interactive command, i.e. no existing script/config or the like should break due to this change.

Resolves #47.
Resolves #135.


## Do not merge before
- [ ] #126 