### PR TITLE
create intermediate folders for cache_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [//]: # (Note: {ref}/{doc} roles are used for references to the documentation)
 
 ## Unreleased
+### Fixed
+- Fixed error if parent(s) of the cache directory do not exist.
 
 ### Changed
 - Moved documentation from GitHub Pages to Read the Docs.  This allows to more easily

--- a/src/cluster_utils/server/utils.py
+++ b/src/cluster_utils/server/utils.py
@@ -287,7 +287,7 @@ def get_cache_directory() -> str:
         cache_dir = os.path.join(home, ".cache", "cluster_utils")
 
     if not os.path.exists(cache_dir):
-        os.mkdir(cache_dir)
+        os.makedirs(cache_dir)
 
     return cache_dir
 


### PR DESCRIPTION
got a file not found error before any jobs started
fixed it by replacing "os.mkdir(cache_dir)" with "os.makedirs(cache_dir)" in line 290 in cluster_utils/server/utils.py  